### PR TITLE
Suggestions

### DIFF
--- a/standard_knowledge_core/Cargo.toml
+++ b/standard_knowledge_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "standard_knowledge"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
 
 [build-dependencies]
 yaml-rust2 = "0.10.3"

--- a/standard_knowledge_core/src/cf.rs
+++ b/standard_knowledge_core/src/cf.rs
@@ -21,7 +21,7 @@ pub fn aliases_by_standard_name() -> HashMap<&'static str, Vec<&'static str>> {
 }
 
 /// Returns a HashMap of standard names to Standard
-pub fn cf_standards() -> HashMap<&'static str, Standard> {
+pub fn cf_standards() -> HashMap<String, Standard> {
     let alias_map = aliases_by_standard_name();
 
     let mut standards = HashMap::new();
@@ -32,7 +32,7 @@ pub fn cf_standards() -> HashMap<&'static str, Standard> {
         let aliases = aliases.iter().map(|alias| alias.to_string()).collect();
 
         standards.insert(
-            name,
+            name.to_string(),
             Standard {
                 name: name.to_string(),
                 unit: unit.to_string(),

--- a/standard_knowledge_core/src/ioos_categories.rs
+++ b/standard_knowledge_core/src/ioos_categories.rs
@@ -1,6 +1,6 @@
 // Categories from https://github.com/ERDDAP/erddap/blob/26c55b4f125ece1e70081a4c46565cf4b8bd6eda/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java#L119
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum IOOSCategory {
     Bathymetry,
     Biology, // bob added

--- a/standard_knowledge_core/src/ioos_categories.rs
+++ b/standard_knowledge_core/src/ioos_categories.rs
@@ -1,123 +1,53 @@
 // Categories from https://github.com/ERDDAP/erddap/blob/26c55b4f125ece1e70081a4c46565cf4b8bd6eda/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java#L119
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum IOOSCategory {
-    Bathymetry,
-    Biology, // bob added
-    BottomCharacter,
-    CO2,                           // bob added pCO2 2011-05-19, 2011-10-11 changed to CO2
-    ColoredDissolvedOrganicMatter, // added 2011-05-19
-    Contaminants,
-    Currents, // was "Surface Currents"
-    DissolvedNutrients,
-    DissolvedO2,
-    Ecology, // bob added
-    FishAbundance,
-    FishSpecies,
-    HeatFlux,
-    Hydrology, // bob added 2011-02-07
-    IceDistribution,
-    Identifier,
-    Location,    // bob added
-    Meteorology, // bob added; use if not Temperature or Wind
-    OceanColor,
-    OpticalProperties, // what is dividing line?  OptProp is for atmosphere, too
-    Other,             // bob added
-    Pathogens,
-    PhysicalOceanography, // Bob added 2011-10-11
-    PhytoplanktonSpecies, // ??the species name? better to use Taxonomy??  Add
-    //   // "Phytoplankton
-    //   // Abundance"?
-    Pressure,     // bob added
-    Productivity, // bob added
-    Quality,      // bob added 2010-11-10
-    Salinity,
-    SeaLevel,
-    Soils,      // bob added 2011-10-06
-    Statistics, // bob added 2010-12-24
-    StreamFlow, // added 2011-05-19
-    SurfaceWaves,
-    Taxonomy, // bob added
-    Temperature,
-    Time,                 // bob added
-    TotalSuspendedMatter, // added 2011-05-19
-    Unknown,
-    Wind, // had Wind. 2011-05-19 has "Wind Speed and Direction", but that seems
-    //   // unnecessarily
-    //   // limited
-    ZooplanktonSpecies, // ??the species name? better to use Taxonomy??
-    ZooplanktonAbundance,
+use std::collections::HashSet;
+
+pub fn erddap_categories() -> HashSet<&'static str> {
+    HashSet::from([
+        "Bathymetry",
+        "Biology", // bob added
+        "Bottom Character",
+        "CO2", // bob added pCO2 2011-05-19, 2011-10-11 changed to CO2
+        "Colored Dissolved Organic Matter", // added 2011-05-19
+        "Contaminants",
+        "Currents", // was "Surface Currents"
+        "Dissolved Nutrients",
+        "Dissolved O2",
+        "Ecology", // bob added
+        "Fish Abundance",
+        "Fish Species",
+        "Heat Flux",
+        "Hydrology", // bob added 2011-02-07
+        "Ice Distribution",
+        "Identifier",
+        "Location",    // bob added
+        "Meteorology", // bob added; use if not Temperature or Wind
+        "Ocean Color",
+        "Optical Properties", // what is dividing line?  OptProp is for atmosphere, too
+        "Other",              // bob added
+        "Pathogens",
+        "Physical Oceanography", // Bob added 2011-10-11
+        "Phytoplankton Species", // ??the species name? better to use Taxonomy??  Add
+        // "Phytoplankton
+        // Abundance"?
+        "Pressure",     // bob added
+        "Productivity", // bob added
+        "Quality",      // bob added 2010-11-10
+        "Salinity",
+        "Sea Level",
+        "Soils",       // bob added 2011-10-06
+        "Statistics",  // bob added 2010-12-24
+        "Stream Flow", // added 2011-05-19
+        "Surface Waves",
+        "Taxonomy", // bob added
+        "Temperature",
+        "Time",                   // bob added
+        "Total Suspended Matter", // added 2011-05-19
+        "Unknown",
+        "Wind", // had Wind. 2011-05-19 has "Wind Speed and Direction", but that seems
+        // unnecessarily
+        // limited
+        "Zooplankton Species", // ??the species name? better to use Taxonomy??
+        "Zooplankton Abundance",
+    ])
 }
-
-// impl IOOSCategory {
-//     fn as_str(&self) -> &'static str {
-//         match self {
-//             IOOSCategory::Bathymetry => "Bathymetry",
-//             IOOSCategory::Biology => "Biology", // bob added
-//             IOOSCategory::BottomCharacter => "Bottom Character",
-//             IOOSCategory::CO2 => "CO2", // bob added pCO2 2011-05-19, 2011-10-11 changed to CO2
-//             IOOSCategory::ColoredDissolvedOrganicMatter => "Colored Dissolved Organic Matter", // added 2011-05-19
-//             IOOSCategory::Contaminants => "Contaminants",
-//             IOOSCategory::Currents => "Currents", // was "Surface Currents"
-//             IOOSCategory::DissolvedNutrients => "Dissolved Nutrients",
-//             IOOSCategory::DissolvedO2 => "Dissolved O2",
-//             IOOSCategory::Ecology => "Ecology", // bob added
-//             IOOSCategory::FishAbundance => "Fish Abundance",
-//             IOOSCategory::FishSpecies => "Fish Species",
-//             IOOSCategory::HeatFlux => "Heat Flux",
-//             IOOSCategory::Hydrology => "Hydrology", // bob added 2011-02-07
-//             IOOSCategory::IceDistribution => "Ice Distribution",
-//             IOOSCategory::Identifier => "Identifier",
-//             IOOSCategory::Location => "Location", // bob added
-//             IOOSCategory::Meteorology => "Meteorology", // bob added; use if not Temperature or Wind
-//             IOOSCategory::OceanColor => "Ocean Color",
-//             IOOSCategory::OpticalProperties => "Optical Properties", // what is dividing line?  OptProp is for atmosphere, too
-//             IOOSCategory::Other => "Other",                          // bob added
-//             IOOSCategory::Pathogens => "Pathogens",
-//             IOOSCategory::PhysicalOceanography => "Physical Oceanography", // Bob added 2011-10-11
-//             IOOSCategory::PhytoplanktonSpecies => "Phytoplankton Species", // ??the species name? better to use Taxonomy??  Add
-//             // "Phytoplankton
-//             // Abundance"?
-//             IOOSCategory::Pressure => "Pressure", // bob added
-//             IOOSCategory::Productivity => "Productivity", // bob added
-//             IOOSCategory::Quality => "Quality",   // bob added 2010-11-10
-//             IOOSCategory::Salinity => "Salinity",
-//             IOOSCategory::SeaLevel => "Sea Level",
-//             IOOSCategory::Soils => "Soils", // bob added 2011-10-06
-//             IOOSCategory::Statistics => "Statistics", // bob added 2010-12-24
-//             IOOSCategory::StreamFlow => "Stream Flow", // added 2011-05-19
-//             IOOSCategory::SurfaceWaves => "Surface Waves",
-//             IOOSCategory::Taxonomy => "Taxonomy", // bob added
-//             IOOSCategory::Temperature => "Temperature",
-//             IOOSCategory::Time => "Time", // bob added
-//             IOOSCategory::TotalSuspendedMatter => "Total Suspended Matter", // added 2011-05-19
-//             IOOSCategory::Unknown => "Unknown",
-//             IOOSCategory::Wind => "Wind", // had Wind. 2011-05-19 has "Wind Speed and Direction", but that seems
-//             // unnecessarily
-//             // limited
-//             IOOSCategory::ZooplanktonSpecies => "Zooplankton Species", // ??the species name? better to use Taxonomy??
-//             IOOSCategory::ZooplanktonAbundance => "Zooplankton Abundance",
-//         }
-//     }
-// }
-
-// impl IOOSCategory {
-// pub fn from_str(s: &str) -> Option<Self> {
-//     match s {
-//         "Bathymetry" => Some(IOOSCategory::Bathymetry),
-//         "Biology" => Some(IOOSCategory::Biology),
-//         "Bottom_Character" => Some(IOOSCategory::Bottom_Character),
-//         "CO2" => Some(IOOSCategory::CO2),
-//         "Colored Dissolved Organic Matter" => Some(IOOSCategory::Colored_Dissolved_Organic_Matter),
-//         "Contaminants" => Some(IOOSCategory::Contaminants),
-//         "Currents" => Some(IOOSCategory::Currents),
-//         "Dissolved Nutrients" => Some(IOOSCategory::Dissolved_Nutrients),
-//         "Dissolved O2" => Some(IOOSCategory::Dissolved_O2),
-//         "Ecology" => Some(IOOSCategory::Ecology),
-//         "Fish Abundance" => Some(IOOSCategory::Fish_Abundance),
-//         "Fish Species" => Some(IOOSCategory::Fish_Species),
-//         "Heat Flux" => Some(IOOSCategory::Heat_Flux),
-//     }
-// }
-
-// }

--- a/standard_knowledge_core/src/main.rs
+++ b/standard_knowledge_core/src/main.rs
@@ -1,14 +1,13 @@
+use std::path::PathBuf;
+
 use standard_knowledge::standards_library::StandardsLibrary;
 
 fn main() {
-    let mut standards = StandardsLibrary::default();
-    standards.load_cf_standards();
+    let mut library = StandardsLibrary::default();
+    library.load_cf_standards();
     println!(
         "By name: {:?}",
-        &standards.get("air_pressure_at_mean_sea_level")
+        &library.get("air_pressure_at_mean_sea_level")
     );
-    println!(
-        "By alias: {:?}",
-        &standards.get("air_pressure_at_sea_level")
-    )
+    println!("By alias: {:?}", &library.get("air_pressure_at_sea_level"));
 }

--- a/standard_knowledge_core/src/main.rs
+++ b/standard_knowledge_core/src/main.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use standard_knowledge::standards_library::StandardsLibrary;
 
 fn main() {

--- a/standard_knowledge_core/src/standard.rs
+++ b/standard_knowledge_core/src/standard.rs
@@ -1,8 +1,11 @@
 use crate::ioos_categories::IOOSCategory;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Standard {
     pub name: String,
+
+    /// Human readable name
+    pub long_name: Option<String>,
     pub unit: String,
     pub description: String,
     pub aliases: Vec<String>,
@@ -28,6 +31,9 @@ pub struct Standard {
 pub struct Suggestion {
     /// Standard name the suggestion applies to
     pub name: String,
+
+    /// Human readable name
+    pub long_name: Option<String>,
 
     /// Usual IOOS category for the standard
     pub ioos_category: Option<IOOSCategory>,

--- a/standard_knowledge_core/src/standard.rs
+++ b/standard_knowledge_core/src/standard.rs
@@ -1,5 +1,3 @@
-use crate::ioos_categories::IOOSCategory;
-
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Standard {
     pub name: String,
@@ -11,7 +9,7 @@ pub struct Standard {
     pub aliases: Vec<String>,
 
     /// Usual IOOS category for the standard
-    pub ioos_category: Option<IOOSCategory>,
+    pub ioos_category: Option<String>,
 
     /// Common variable names in a dataset
     pub common_variable_names: Vec<String>,
@@ -36,7 +34,7 @@ pub struct Suggestion {
     pub long_name: Option<String>,
 
     /// Usual IOOS category for the standard
-    pub ioos_category: Option<IOOSCategory>,
+    pub ioos_category: Option<String>,
 
     /// Common variable names in a dataset
     pub common_variable_names: Vec<String>,

--- a/standard_knowledge_core/src/standards_library.rs
+++ b/standard_knowledge_core/src/standards_library.rs
@@ -1,9 +1,9 @@
-use crate::standard::Standard;
+use crate::{Suggestion, standard::Standard};
 use std::collections::HashMap;
 
 #[derive(Debug, Default, Clone)]
 pub struct StandardsLibrary {
-    pub standards: HashMap<&'static str, Standard>,
+    pub standards: HashMap<String, Standard>,
 }
 
 impl StandardsLibrary {
@@ -34,6 +34,34 @@ impl StandardsLibrary {
         Err("Unknown Standard")
     }
 
+    /// Update the loaded standards with suggestions
+    pub fn apply_suggestions(&mut self, suggestions: Vec<Suggestion>) {
+        for suggestion in suggestions {
+            if let Some(standard) = self.standards.get(&suggestion.name) {
+                let mut common_variable_names = standard.common_variable_names.clone();
+                common_variable_names.append(&mut suggestion.common_variable_names.clone());
+
+                let mut related_standards = standard.related_standards.clone();
+                related_standards.append(&mut suggestion.related_standards.clone());
+
+                let mut other_units = standard.other_units.clone();
+                other_units.append(&mut suggestion.other_units.clone());
+
+                let new_standard = Standard {
+                    long_name: suggestion.long_name,
+                    ioos_category: suggestion.ioos_category,
+                    common_variable_names,
+                    related_standards,
+                    other_units: suggestion.other_units,
+                    comments: suggestion.comments,
+                    ..standard.clone()
+                };
+
+                self.standards.insert(suggestion.name, new_standard);
+            }
+        }
+    }
+
     // /// Returns standards that may match a column_name
     // pub fn for_column(&self, column_name: &str) -> Result<Vec<Standard>, &'static str> {
 
@@ -47,23 +75,53 @@ mod tests {
 
     #[test]
     fn can_load_standards() {
-        let mut standards = StandardsLibrary::default();
-        standards.load_cf_standards();
+        let mut library = StandardsLibrary::default();
+        library.load_cf_standards();
     }
 
     #[test]
     fn can_get_standard() {
-        let mut standards = StandardsLibrary::default();
-        standards.load_cf_standards();
-        let pressure = standards.get("air_pressure_at_mean_sea_level").unwrap();
+        let mut library = StandardsLibrary::default();
+        library.load_cf_standards();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
         assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
     }
 
     #[test]
     fn can_get_standard_by_alias() {
-        let mut standards = StandardsLibrary::default();
-        standards.load_cf_standards();
-        let pressure = standards.get("air_pressure_at_sea_level").unwrap();
+        let mut library = StandardsLibrary::default();
+        library.load_cf_standards();
+        let pressure = library.get("air_pressure_at_sea_level").unwrap();
         assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
+    }
+
+    #[test]
+    fn can_apply_suggestions() {
+        let mut library = StandardsLibrary::default();
+        library.load_cf_standards();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
+        assert_eq!(pressure.long_name, None);
+
+        let suggestion = Suggestion {
+            name: "air_pressure_at_mean_sea_level".to_string(),
+            long_name: Some("Air Pressure at Sea Level".to_string()),
+            ioos_category: None,
+            common_variable_names: Vec::new(),
+            related_standards: Vec::new(),
+            other_units: Vec::new(),
+            comments: None,
+        };
+
+        library.apply_suggestions(vec![suggestion]);
+
+        let updated_pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(updated_pressure.name, "air_pressure_at_mean_sea_level");
+        assert_eq!(
+            updated_pressure.long_name.clone().unwrap(),
+            "Air Pressure at Sea Level"
+        );
+
+        assert_ne!(pressure, updated_pressure);
     }
 }

--- a/standard_knowledge_core/src/standards_library.rs
+++ b/standard_knowledge_core/src/standards_library.rs
@@ -34,6 +34,19 @@ impl StandardsLibrary {
         Err("Unknown Standard")
     }
 
+    /// Returns standards that match a given column_name
+    pub fn by_variable_name(&self, variable_name: &str) -> Vec<Standard> {
+        self.standards
+            .values()
+            .filter(|standard| {
+                standard
+                    .common_variable_names
+                    .contains(&variable_name.to_string())
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Update the loaded standards with suggestions
     pub fn apply_suggestions(&mut self, suggestions: Vec<Suggestion>) {
         for suggestion in suggestions {
@@ -61,12 +74,6 @@ impl StandardsLibrary {
             }
         }
     }
-
-    // /// Returns standards that may match a column_name
-    // pub fn for_column(&self, column_name: &str) -> Result<Vec<Standard>, &'static str> {
-
-    //     Err("No standards found")
-    // }
 }
 
 #[cfg(test)]
@@ -123,5 +130,26 @@ mod tests {
         );
 
         assert_ne!(pressure, updated_pressure);
+    }
+
+    #[test]
+    fn can_find_by_column_name() {
+        let mut library = StandardsLibrary::default();
+        library.load_cf_standards();
+        let suggestion = Suggestion {
+            name: "air_pressure_at_mean_sea_level".to_string(),
+            long_name: Some("Air Pressure at Sea Level".to_string()),
+            ioos_category: None,
+            common_variable_names: vec!["pressure".to_string()],
+            related_standards: Vec::new(),
+            other_units: Vec::new(),
+            comments: None,
+        };
+
+        library.apply_suggestions(vec![suggestion]);
+
+        let standards = library.by_variable_name("pressure");
+        let pressure = &standards[0];
+        assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
     }
 }

--- a/standard_knowledge_py/Cargo.toml
+++ b/standard_knowledge_py/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "standard_knowledge_py"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.88"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/standard_knowledge_py/src/standard.rs
+++ b/standard_knowledge_py/src/standard.rs
@@ -5,7 +5,7 @@ use pyo3::{
     prelude::*,
     types::{PyTuple, PyType},
 };
-use standard_knowledge::Standard;
+use standard_knowledge::{Standard, Suggestion};
 
 #[pyclass(name = "Standard")]
 #[derive(Clone)]
@@ -23,6 +23,11 @@ impl PyStandard {
         Ok(self.0.name.clone())
     }
 
+    #[getter]
+    fn long_name(&self) -> PyResult<Option<String>> {
+        Ok(self.0.long_name.clone())
+    }
+
     /// Return a dictionary of Xarray attributes
     fn attrs(&self) -> PyResult<HashMap<&str, &str>> {
         let mut map = HashMap::from([("standard_name", self.0.name.as_str())]);
@@ -31,6 +36,22 @@ impl PyStandard {
             map.insert("units", self.0.unit.as_str());
         }
 
+        if let Some(long_name) = &self.0.long_name
+            && long_name != ""
+        {
+            map.insert("long_name", long_name.as_str());
+        }
+
+        // if let Some(ioos_category) = &self.0.ioos_category && ioos_category != "" {
+        //     map.insert("ioos_category", ioos_category.as_str());
+        // }
+
         Ok(map)
     }
 }
+
+#[pyclass(name = "Suggestion")]
+#[derive(Clone)]
+pub struct PySuggestion(Suggestion);
+
+

--- a/standard_knowledge_py/src/standard.rs
+++ b/standard_knowledge_py/src/standard.rs
@@ -1,11 +1,7 @@
 use std::collections::HashMap;
 
-use pyo3::{
-    exceptions::{PyKeyError, PyValueError},
-    prelude::*,
-    types::{PyTuple, PyType},
-};
-use standard_knowledge::{Standard, Suggestion};
+use pyo3::prelude::*;
+use standard_knowledge::Standard;
 
 #[pyclass(name = "Standard")]
 #[derive(Clone)]
@@ -28,22 +24,62 @@ impl PyStandard {
         Ok(self.0.long_name.clone())
     }
 
+    #[getter]
+    fn unit(&self) -> PyResult<String> {
+        Ok(self.0.unit.clone())
+    }
+
+    #[getter]
+    fn description(&self) -> PyResult<String> {
+        Ok(self.0.description.clone())
+    }
+
+    #[getter]
+    fn aliases(&self) -> PyResult<Vec<String>> {
+        Ok(self.0.aliases.clone())
+    }
+
+    #[getter]
+    fn ioos_category(&self) -> PyResult<Option<String>> {
+        Ok(self.0.ioos_category.clone())
+    }
+
+    #[getter]
+    fn common_variable_names(&self) -> PyResult<Vec<String>> {
+        Ok(self.0.common_variable_names.clone())
+    }
+
+    #[getter]
+    fn related_standards(&self) -> PyResult<Vec<String>> {
+        Ok(self.0.related_standards.clone())
+    }
+
+    #[getter]
+    fn other_units(&self) -> PyResult<Vec<String>> {
+        Ok(self.0.other_units.clone())
+    }
+
+    #[getter]
+    fn comments(&self) -> PyResult<Option<String>> {
+        Ok(self.0.comments.clone())
+    }
+
     /// Return a dictionary of Xarray attributes
     fn attrs(&self) -> PyResult<HashMap<&str, &str>> {
         let mut map = HashMap::from([("standard_name", self.0.name.as_str())]);
 
-        if self.0.unit != "" {
+        if !self.0.unit.is_empty() {
             map.insert("units", self.0.unit.as_str());
         }
 
         if let Some(long_name) = &self.0.long_name
-            && long_name != ""
+            && !long_name.is_empty()
         {
             map.insert("long_name", long_name.as_str());
         }
 
         if let Some(ioos_category) = &self.0.ioos_category
-            && ioos_category != ""
+            && !ioos_category.is_empty()
         {
             map.insert("ioos_category", ioos_category.as_str());
         }
@@ -51,7 +87,3 @@ impl PyStandard {
         Ok(map)
     }
 }
-
-#[pyclass(name = "Suggestion")]
-#[derive(Clone)]
-pub struct PySuggestion(Suggestion);

--- a/standard_knowledge_py/src/standard.rs
+++ b/standard_knowledge_py/src/standard.rs
@@ -42,9 +42,11 @@ impl PyStandard {
             map.insert("long_name", long_name.as_str());
         }
 
-        // if let Some(ioos_category) = &self.0.ioos_category && ioos_category != "" {
-        //     map.insert("ioos_category", ioos_category.as_str());
-        // }
+        if let Some(ioos_category) = &self.0.ioos_category
+            && ioos_category != ""
+        {
+            map.insert("ioos_category", ioos_category.as_str());
+        }
 
         Ok(map)
     }
@@ -53,5 +55,3 @@ impl PyStandard {
 #[pyclass(name = "Suggestion")]
 #[derive(Clone)]
 pub struct PySuggestion(Suggestion);
-
-

--- a/standard_knowledge_py/src/standards_library.rs
+++ b/standard_knowledge_py/src/standards_library.rs
@@ -46,7 +46,11 @@ impl PyStandardsLibrary {
         }
     }
 
-    fn apply_suggestions(&mut self, py: Python, suggestions: Vec<HashMap<String, SuggestionValues>>) -> PyResult<()> {
+    fn apply_suggestions(
+        &mut self,
+        py: Python,
+        suggestions: Vec<HashMap<String, SuggestionValues>>,
+    ) -> PyResult<()> {
         let mut cleaned_suggestions = Vec::new();
 
         for suggestion in suggestions {
@@ -55,10 +59,12 @@ impl PyStandardsLibrary {
                 if let SuggestionValues::String(str_value) = value {
                     name = str_value.to_string();
                 } else {
-                    return Err(PyKeyError::new_err("`name` is not a string in suggestion"))
+                    return Err(PyKeyError::new_err("`name` is not a string in suggestion"));
                 }
             } else {
-                return Err(PyKeyError::new_err("The suggestion needs a name of the standard to be applied to"))
+                return Err(PyKeyError::new_err(
+                    "The suggestion needs a name of the standard to be applied to",
+                ));
             }
 
             let mut long_name = None;
@@ -66,14 +72,23 @@ impl PyStandardsLibrary {
                 if let SuggestionValues::String(str_value) = value {
                     long_name = Some(str_value.to_string());
                 } else {
-                    return Err(PyKeyError::new_err("`long_name` can only be a string"))
+                    return Err(PyKeyError::new_err("`long_name` can only be a string"));
+                }
+            }
+
+            let mut ioos_category = None;
+            if let Some(value) = suggestion.get("ioos_category") {
+                if let SuggestionValues::String(str_value) = value {
+                    ioos_category = Some(str_value.to_string());
+                } else {
+                    return Err(PyKeyError::new_err("`ioos_category` must be a string"));
                 }
             }
 
             let cleaned = Suggestion {
                 name,
                 long_name,
-                ioos_category: None,
+                ioos_category,
                 common_variable_names: Vec::new(),
                 related_standards: Vec::new(),
                 other_units: Vec::new(),

--- a/standard_knowledge_py/src/standards_library.rs
+++ b/standard_knowledge_py/src/standards_library.rs
@@ -42,6 +42,17 @@ impl PyStandardsLibrary {
         }
     }
 
+    /// Return standards that match a given variable name
+    fn by_variable_name(&self, variable_name: &str) -> PyResult<Vec<PyStandard>> {
+        let standards = self.0.by_variable_name(variable_name);
+
+        Ok(standards
+            .iter()
+            .map(|standard| PyStandard(standard.clone()))
+            .collect())
+    }
+
+    /// Apply suggestions to loaded standards
     fn apply_suggestions(
         &mut self,
         suggestions: Vec<HashMap<String, SuggestionValues>>,

--- a/standard_knowledge_py/tests/test_standard.py
+++ b/standard_knowledge_py/tests/test_standard.py
@@ -1,6 +1,18 @@
 import standard_knowledge
 
 
+def test_get_standard():
+    library = standard_knowledge.StandardsLibrary()
+    library.load_cf_standards()
+
+    standard = library.get("air_pressure_at_mean_sea_level")
+
+    assert standard.name == "air_pressure_at_mean_sea_level"
+    assert standard.long_name is None
+    assert standard.unit == "Pa"
+    assert "Air pressure is the force per unit" in standard.description 
+    assert "air_pressure_at_sea_level" in standard.aliases
+
 def test_get_standard_attrs():
     library = standard_knowledge.StandardsLibrary()
     library.load_cf_standards()

--- a/standard_knowledge_py/tests/test_standard.py
+++ b/standard_knowledge_py/tests/test_standard.py
@@ -4,9 +4,20 @@ import standard_knowledge
 def test_get_standard_attrs():
     library = standard_knowledge.StandardsLibrary()
     library.load_cf_standards()
+
+    suggestion = {
+        "name": "air_pressure_at_mean_sea_level",
+        "long_name": "Air Pressure at Sea Level",
+        # "ioos_category": "Meteorology",
+    }
+
+    library.apply_suggestions([suggestion])
+
     standard = library.get("air_pressure_at_mean_sea_level")
 
     attrs = standard.attrs()
 
     assert attrs["standard_name"] == "air_pressure_at_mean_sea_level"
     assert attrs["units"] == "Pa"
+    assert attrs["long_name"] == "Air Pressure at Sea Level"
+    # assert attrs["ioos_category"] == "Meteorology"

--- a/standard_knowledge_py/tests/test_standard.py
+++ b/standard_knowledge_py/tests/test_standard.py
@@ -10,8 +10,9 @@ def test_get_standard():
     assert standard.name == "air_pressure_at_mean_sea_level"
     assert standard.long_name is None
     assert standard.unit == "Pa"
-    assert "Air pressure is the force per unit" in standard.description 
+    assert "Air pressure is the force per unit" in standard.description
     assert "air_pressure_at_sea_level" in standard.aliases
+
 
 def test_get_standard_attrs():
     library = standard_knowledge.StandardsLibrary()

--- a/standard_knowledge_py/tests/test_standard.py
+++ b/standard_knowledge_py/tests/test_standard.py
@@ -8,7 +8,7 @@ def test_get_standard_attrs():
     suggestion = {
         "name": "air_pressure_at_mean_sea_level",
         "long_name": "Air Pressure at Sea Level",
-        # "ioos_category": "Meteorology",
+        "ioos_category": "Meteorology",
     }
 
     library.apply_suggestions([suggestion])
@@ -20,4 +20,4 @@ def test_get_standard_attrs():
     assert attrs["standard_name"] == "air_pressure_at_mean_sea_level"
     assert attrs["units"] == "Pa"
     assert attrs["long_name"] == "Air Pressure at Sea Level"
-    # assert attrs["ioos_category"] == "Meteorology"
+    assert attrs["ioos_category"] == "Meteorology"

--- a/standard_knowledge_py/tests/test_standards_library.py
+++ b/standard_knowledge_py/tests/test_standards_library.py
@@ -41,22 +41,32 @@ def test_suggestions_must_have_name():
     assert "name of the standard" in str(e.value)
 
 
-# def test_can_add_suggestions():
-#     library = standard_knowledge.StandardsLibrary()
-#     library.load_cf_standards()
-#     standard = library.get("air_pressure_at_sea_level")
-#     assert standard.name == "air_pressure_at_mean_sea_level"
-#     assert standard.long_name is None
+def test_can_add_suggestions():
+    library = standard_knowledge.StandardsLibrary()
+    library.load_cf_standards()
+    standard = library.get("air_pressure_at_sea_level")
+    assert standard.name == "air_pressure_at_mean_sea_level"
+    assert standard.long_name is None
 
-#     suggestion = {
-#         "name": "air_pressure_at_mean_sea_level",
-#         "long_name": "Air Pressure at Sea Level"
-#     }
+    suggestion = {
+        "name": "air_pressure_at_mean_sea_level",
+        "long_name": "Air Pressure at Sea Level",
+        "ioos_category": "Meteorology",
+        "common_variable_names": ["air_pressure", "pressure"],
+        "related_standards": ["air_pressure"],
+        "other_units": ["bar"],
+        "comments": "Some adjustment for altitude may be needed"
+    }
 
-#     library.apply_suggestions([suggestion])
+    library.apply_suggestions([suggestion])
 
-#     updated_standard = library.get("air_pressure_at_sea_level")
-#     assert updated_standard.name == "air_pressure_at_mean_sea_level"
-#     assert updated_standard.long_name == "Air Pressure at Sea Level"
+    updated_standard = library.get("air_pressure_at_sea_level")
+    assert updated_standard.name == suggestion["name"]
+    assert updated_standard.long_name == suggestion["long_name"]
+    assert updated_standard.ioos_category == suggestion["ioos_category"]
+    assert "pressure" in updated_standard.common_variable_names
+    assert "air_pressure" in updated_standard.related_standards
+    assert "bar" in updated_standard.other_units
+    assert updated_standard.comments == suggestion["comments"]
 
-#     assert standard != updated_standard
+    assert standard != updated_standard

--- a/standard_knowledge_py/tests/test_standards_library.py
+++ b/standard_knowledge_py/tests/test_standards_library.py
@@ -27,3 +27,38 @@ def test_unknown_standard():
     library = standard_knowledge.StandardsLibrary()
     with pytest.raises(KeyError):
         library.get("air_pressure_at_sea_level")
+
+
+def test_suggestions_must_have_name():
+    library = standard_knowledge.StandardsLibrary()
+    library.load_cf_standards()
+
+    suggestion = {
+        "long_name": "Air Pressure"
+    }
+
+    with pytest.raises(KeyError) as e:
+        library.apply_suggestions([suggestion])
+
+    assert "name of the standard" in str(e.value)
+
+
+# def test_can_add_suggestions():
+#     library = standard_knowledge.StandardsLibrary()
+#     library.load_cf_standards()
+#     standard = library.get("air_pressure_at_sea_level")
+#     assert standard.name == "air_pressure_at_mean_sea_level"
+#     assert standard.long_name is None
+
+#     suggestion = {
+#         "name": "air_pressure_at_mean_sea_level",
+#         "long_name": "Air Pressure at Sea Level"
+#     }
+
+#     library.apply_suggestions([suggestion])
+
+#     updated_standard = library.get("air_pressure_at_sea_level")
+#     assert updated_standard.name == "air_pressure_at_mean_sea_level"
+#     assert updated_standard.long_name == "Air Pressure at Sea Level"
+
+#     assert standard != updated_standard

--- a/standard_knowledge_py/tests/test_standards_library.py
+++ b/standard_knowledge_py/tests/test_standards_library.py
@@ -33,9 +33,7 @@ def test_suggestions_must_have_name():
     library = standard_knowledge.StandardsLibrary()
     library.load_cf_standards()
 
-    suggestion = {
-        "long_name": "Air Pressure"
-    }
+    suggestion = {"long_name": "Air Pressure"}
 
     with pytest.raises(KeyError) as e:
         library.apply_suggestions([suggestion])

--- a/standard_knowledge_py/tests/test_standards_library.py
+++ b/standard_knowledge_py/tests/test_standards_library.py
@@ -3,6 +3,17 @@ import pytest
 import standard_knowledge
 
 
+SUGGESTION = {
+    "name": "air_pressure_at_mean_sea_level",
+    "long_name": "Air Pressure at Sea Level",
+    "ioos_category": "Meteorology",
+    "common_variable_names": ["air_pressure", "pressure"],
+    "related_standards": ["air_pressure"],
+    "other_units": ["bar"],
+    "comments": "Some adjustment for altitude may be needed",
+}
+
+
 def test_library_load_standards():
     library = standard_knowledge.StandardsLibrary()
     library.load_cf_standards()
@@ -48,25 +59,26 @@ def test_can_add_suggestions():
     assert standard.name == "air_pressure_at_mean_sea_level"
     assert standard.long_name is None
 
-    suggestion = {
-        "name": "air_pressure_at_mean_sea_level",
-        "long_name": "Air Pressure at Sea Level",
-        "ioos_category": "Meteorology",
-        "common_variable_names": ["air_pressure", "pressure"],
-        "related_standards": ["air_pressure"],
-        "other_units": ["bar"],
-        "comments": "Some adjustment for altitude may be needed"
-    }
-
-    library.apply_suggestions([suggestion])
+    library.apply_suggestions([SUGGESTION])
 
     updated_standard = library.get("air_pressure_at_sea_level")
-    assert updated_standard.name == suggestion["name"]
-    assert updated_standard.long_name == suggestion["long_name"]
-    assert updated_standard.ioos_category == suggestion["ioos_category"]
+    assert updated_standard.name == SUGGESTION["name"]
+    assert updated_standard.long_name == SUGGESTION["long_name"]
+    assert updated_standard.ioos_category == SUGGESTION["ioos_category"]
     assert "pressure" in updated_standard.common_variable_names
     assert "air_pressure" in updated_standard.related_standards
     assert "bar" in updated_standard.other_units
-    assert updated_standard.comments == suggestion["comments"]
+    assert updated_standard.comments == SUGGESTION["comments"]
 
     assert standard != updated_standard
+
+
+def test_find_standards_by_variable_names():
+    library = standard_knowledge.StandardsLibrary()
+    library.load_cf_standards()
+    library.apply_suggestions([SUGGESTION])
+
+    standards = library.by_variable_name("pressure")
+
+    standard = standards[0]
+    assert standard.name == SUGGESTION["name"]

--- a/utils/update_standards.py
+++ b/utils/update_standards.py
@@ -15,7 +15,9 @@ from bs4 import BeautifulSoup
 import yaml
 
 standards_url = "https://raw.githubusercontent.com/cf-convention/vocabularies/refs/heads/main/docs/cf-standard-names/current/cf-standard-name-table.xml"
-cf_yaml = Path(__file__).parent / "../standards/_cf_standards.yaml"
+cf_yaml = (
+    Path(__file__).parent / "../standard_knowledge_core/standards/_cf_standards.yaml"
+)
 
 standard_names = {}
 aliases = {}


### PR DESCRIPTION
Allows programmatic loading of suggestions from Rust and Python, and 
applying those suggestions to standards.

And now that we can load suggestions we can find standards by variable names.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13 
- <kbd>&nbsp;1&nbsp;</kbd> #11 👈 
<!-- GitButler Footer Boundary Bottom -->

