### PR TITLE
Search

### DIFF
--- a/standard_knowledge_core/src/standard.rs
+++ b/standard_knowledge_core/src/standard.rs
@@ -24,6 +24,45 @@ pub struct Standard {
     pub comments: Option<String>,
 }
 
+impl Standard {
+    /// Do any of the fields in the standard match a search pattern
+    pub fn matches_pattern(&self, search_str: &str) -> bool {
+        let search_str = search_str.to_lowercase();
+        let search_str = search_str.as_str();
+        self.name.to_lowercase().contains(search_str)
+            || self
+                .long_name
+                .as_ref()
+                .is_some_and(|name| name.to_lowercase().contains(search_str))
+            || self.unit.to_lowercase().contains(search_str)
+            || self.description.to_lowercase().contains(search_str)
+            || self
+                .aliases
+                .iter()
+                .any(|alias| alias.to_lowercase().contains(search_str))
+            || self
+                .ioos_category
+                .as_ref()
+                .is_some_and(|category| category.to_lowercase().contains(search_str))
+            || self
+                .common_variable_names
+                .iter()
+                .any(|name| name.to_lowercase().contains(search_str))
+            || self
+                .related_standards
+                .iter()
+                .any(|name| name.to_lowercase().contains(search_str))
+            || self
+                .other_units
+                .iter()
+                .any(|unit| unit.to_lowercase().contains(search_str))
+            || self
+                .comments
+                .as_ref()
+                .is_some_and(|comment| comment.to_lowercase().contains(search_str))
+    }
+}
+
 /// A suggestion is a subset of a Standard
 #[derive(Clone, Debug)]
 pub struct Suggestion {
@@ -47,4 +86,35 @@ pub struct Suggestion {
 
     /// Community comments on standard usage
     pub comments: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_match_standard_by_long_name() {
+        let standard = Standard {
+            name: "air_pressure_at_mean_sea_level".to_string(),
+            long_name: None,
+            unit: "Pa".to_string(),
+            description: "A quick note".to_string(),
+            aliases: Vec::new(),
+            ioos_category: Some("Meteorology".to_string()),
+            common_variable_names: Vec::new(),
+            related_standards: Vec::new(),
+            other_units: Vec::new(),
+            comments: None,
+        };
+
+        assert!(
+            standard.matches_pattern("Met"),
+            "Should be able to find met within the standard",
+        );
+
+        assert!(
+            !standard.matches_pattern("Nothing"),
+            "Shouldn't match something random"
+        );
+    }
 }

--- a/standard_knowledge_core/src/standards_library.rs
+++ b/standard_knowledge_core/src/standards_library.rs
@@ -47,6 +47,33 @@ impl StandardsLibrary {
             .collect()
     }
 
+    /// Return standards that have a string across multiple fields,
+    /// hopefully in a relevant order
+    pub fn search(&self, search_str: &str) -> Vec<Standard> {
+        let mut standards = Vec::new();
+
+        if let Ok(standard) = self.get(search_str) {
+            standards.push(standard);
+        }
+
+        let by_variable = self.by_variable_name(search_str);
+
+        for standard in by_variable {
+            if !standards.contains(&standard) {
+                standards.push(standard);
+            }
+        }
+
+        // Search for partial matches
+        for standard in self.standards.values() {
+            if !standards.contains(standard) && standard.matches_pattern(search_str) {
+                standards.push(standard.clone());
+            }
+        }
+
+        standards
+    }
+
     /// Update the loaded standards with suggestions
     pub fn apply_suggestions(&mut self, suggestions: Vec<Suggestion>) {
         for suggestion in suggestions {

--- a/standard_knowledge_py/Readme.md
+++ b/standard_knowledge_py/Readme.md
@@ -15,6 +15,12 @@ standard = library.get("air_pressure_at_mean_sea_level")
 
 # Xarray compatible attributes for a standard
 attrs = standard.attrs()
+
+# find standards by variable names
+standards = library.by_variable_name("pressure")
+
+# Search for standards across multiple fields (name, aliases, common variable names, related standards)
+under_pressure = library.search("pressure")
 ```
 
 Test with `uv run pytest`

--- a/standard_knowledge_py/src/standards_library.rs
+++ b/standard_knowledge_py/src/standards_library.rs
@@ -52,6 +52,17 @@ impl PyStandardsLibrary {
             .collect())
     }
 
+    /// Return standards that have a string across multiple fields,
+    /// hopefully in a relevant order
+    fn search(&self, search_str: &str) -> PyResult<Vec<PyStandard>> {
+        let standards = self.0.search(search_str);
+
+        Ok(standards
+            .iter()
+            .map(|standard| PyStandard(standard.clone()))
+            .collect())
+    }
+
     /// Apply suggestions to loaded standards
     fn apply_suggestions(
         &mut self,

--- a/standard_knowledge_py/tests/test_standards_library.py
+++ b/standard_knowledge_py/tests/test_standards_library.py
@@ -82,3 +82,17 @@ def test_find_standards_by_variable_names():
 
     standard = standards[0]
     assert standard.name == SUGGESTION["name"]
+
+
+def test_search_standard():
+    library = standard_knowledge.StandardsLibrary()
+    library.load_cf_standards()
+    library.apply_suggestions([SUGGESTION])
+
+    standards = library.search("pressure")
+
+    assert len(standards) > 0
+    pressure = standards[0]
+    assert pressure.name == SUGGESTION["name"], (
+        "since there isn't a direct name or alias match, the suggested column should make it first"
+    )


### PR DESCRIPTION
Allows searching the library for standards by multiple fields

Matches first by name & alias, then variable names, then partial matches
from all fields.