### PR TITLE
Use &str

### DIFF
--- a/cli/src/qc.rs
+++ b/cli/src/qc.rs
@@ -100,17 +100,17 @@ pub fn execute(qc_args: &QcArgs, library: &StandardsLibrary) {
                     for arg in args {
                         let parts: Vec<&str> = arg.split('=').collect();
                         if parts.len() == 2 {
-                            let key = parts[0].to_string();
-                            let value = parts[1].to_string();
+                            let key = parts[0];
+                            let value = parts[1];
 
                             let arg_type = info
                                 .arguments
-                                .get(&key)
+                                .get(key)
                                 .map(|arg| arg.argument_type.clone())
                                 .unwrap_or(ArgumentType::String);
                             let arg_value = arg_type.value_type(value);
 
-                            arguments.insert(key, arg_value);
+                            arguments.insert(key.to_string(), arg_value);
                         } else {
                             eprintln!("Invalid argument format: {arg}");
                             process::exit(2);

--- a/core/src/qartod/types.rs
+++ b/core/src/qartod/types.rs
@@ -35,7 +35,7 @@ impl TestSuiteInfo {
         if !self.arguments.is_empty() {
             output.push_str("\n\nArguments:");
             let mut sorted_args: Vec<_> = self.arguments.iter().collect();
-            sorted_args.sort_by_key(|(name, _)| name.clone());
+            sorted_args.sort_by_key(|(name, _)| *name);
             for (name, arg) in sorted_args {
                 output.push_str(&format!("\n- {}: {}", name, arg.description));
                 if arg.required {
@@ -66,9 +66,9 @@ pub enum ArgumentType {
 }
 
 impl ArgumentType {
-    pub fn value_type(&self, value: String) -> ArgumentValue {
+    pub fn value_type(&self, value: &str) -> ArgumentValue {
         match self {
-            ArgumentType::String => ArgumentValue::String(value),
+            ArgumentType::String => ArgumentValue::String(value.to_string()),
             ArgumentType::Bool => ArgumentValue::Bool(value.parse().unwrap_or_default()),
             ArgumentType::Int => ArgumentValue::Int(value.parse().unwrap_or_default()),
             ArgumentType::Float => ArgumentValue::Float(value.parse().unwrap_or_default()),

--- a/core/src/standard.rs
+++ b/core/src/standard.rs
@@ -102,7 +102,7 @@ impl Standard {
                 "{output}\n\nQARTOD Test Suites:\n- {}",
                 self.qartod
                     .iter()
-                    .map(|suite| format!("{}", suite.info()))
+                    .map(|suite| suite.info().to_string())
                     .collect::<Vec<_>>()
                     .join("\n- ")
             );

--- a/core/src/standards_library.rs
+++ b/core/src/standards_library.rs
@@ -23,7 +23,8 @@ impl StandardsLibrary {
         for standard in self.standards.values() {
             if standard
                 .aliases
-                .contains(&standard_name_or_alias.to_string())
+                .iter()
+                .any(|alias| alias == standard_name_or_alias)
             {
                 return Ok(standard.clone());
             }
@@ -39,7 +40,8 @@ impl StandardsLibrary {
             .filter(|standard| {
                 standard
                     .common_variable_names
-                    .contains(&variable_name.to_string())
+                    .iter()
+                    .any(|name| name == variable_name)
             })
             .cloned()
             .collect()
@@ -176,7 +178,7 @@ mod tests {
         let updated_pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
         assert_eq!(updated_pressure.name, "air_pressure_at_mean_sea_level");
         assert_eq!(
-            updated_pressure.long_name.clone().unwrap(),
+            updated_pressure.long_name.as_ref().unwrap(),
             "Air Pressure at Sea Level"
         );
 

--- a/py/src/standards_library.rs
+++ b/py/src/standards_library.rs
@@ -74,7 +74,7 @@ impl PyStandardsLibrary {
             let name;
             if let Some(value) = know.get("name") {
                 if let KnowledgeValues::String(str_value) = value {
-                    name = str_value.to_string();
+                    name = str_value.clone();
                 } else {
                     return Err(PyKeyError::new_err("`name` is not a string in knowledge"));
                 }
@@ -126,7 +126,7 @@ fn get_string_field(
     key: &str,
 ) -> PyResult<Option<String>> {
     match knowledge.get(key) {
-        Some(KnowledgeValues::String(str_value)) => Ok(Some(str_value.to_string())),
+        Some(KnowledgeValues::String(str_value)) => Ok(Some(str_value.clone())),
         Some(_) => Err(PyKeyError::new_err(format!(
             "`{key}` must be a string field"
         ))),


### PR DESCRIPTION
Had Copilot run through and convert `String` to `&str` where it makes 
sense, doesn’t add complexity, and makes things more flexible.