### PR TITLE
Knowledge from NERACOOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,29 @@ common_variable_names:
 - sea_level_pressure
 related_standards:
 - air_pressure
+sibling_standards:
+- air_temperature
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: PRESSURE - BAROMETRIC
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0015
 other_units:
 - kPa
 - bar
 comments: |
   Raw pressure sensor values on buoys may need to be adjusted based on sensor tower height.
 ```
+
+Knowledge keys:
+
+- `ioos_category` - Category of measurement for the Integrated Ocean Observing System
+- `long_name` - A more human readable name for the standard
+- `common_variable_names` - When the standard name isn't used for a column or variable, what might commonly get used instead.
+- `related_standards` - Standards that measure generally similar things, but differ in specifics that are worth investigating.
+- `sibling_standards` - Standards that are usually used together.
+- `extra_attrs` - Dictionary of extra attributes to be applied to Xarray or ERDDAP.
+- `other_units` - Other units that may be used rather than the one defined in the standard.
+- `comments` - What others may need to know about a standard. How is the standard used, rather than the CF description of how it is defined. Notes about implementation.
 
 > [!NOTE]
 >

--- a/cli/tests/cmd/get-with-tests.toml
+++ b/cli/tests/cmd/get-with-tests.toml
@@ -1,8 +1,9 @@
 bin.name = "standard_knowledge"
 args = ["get", "sea_surface_height_above_geopotential_datum"]
 stdout = """
-sea_surface_height_above_geopotential_datum - m
+sea_surface_height_above_geopotential_datum - Sea surface height above geopotential datum - m
   IOOS Category: Sea Level
+  Sibling standards: tidal_sea_surface_height_above_mean_lower_low_water, tidal_sea_surface_height_above_mean_higher_high_water
 
 QARTOD Test Suites:
 - Gulf of Maine (gulf_of_maine): Water level tests for stations in the Gulf of Maine developed by Hannah Baranes

--- a/cli/tests/cmd/search-xarray.toml
+++ b/cli/tests/cmd/search-xarray.toml
@@ -15,11 +15,24 @@ stdout = """
 },
 {
   "ioos_category": "Sea Level",
+  "long_name": "Sea surface height above geopotential datum",
   "standard_name": "sea_surface_height_above_geopotential_datum",
   "units": "m",
 },
 {
   "standard_name": "surface_height_above_geopotential_datum",
+  "units": "m",
+},
+{
+  "ioos_category": "Sea Level",
+  "long_name": "Mean Higher High Water",
+  "standard_name": "tidal_sea_surface_height_above_mean_higher_high_water",
+  "units": "m",
+},
+{
+  "ioos_category": "Sea Level",
+  "long_name": "Mean Lower Low Water",
+  "standard_name": "tidal_sea_surface_height_above_mean_lower_low_water",
   "units": "m",
 }
 """

--- a/cli/tests/cmd/search.toml
+++ b/cli/tests/cmd/search.toml
@@ -4,6 +4,8 @@ stdout = """
 - height_above_geopotential_datum - m
 - height_above_geopotential_datum_at_top_of_atmosphere_model - m
 - sea_floor_depth_below_geopotential_datum - m
-- sea_surface_height_above_geopotential_datum - m
+- sea_surface_height_above_geopotential_datum - Sea surface height above geopotential datum - m
 - surface_height_above_geopotential_datum - m
+- tidal_sea_surface_height_above_mean_higher_high_water - Mean Higher High Water - m
+- tidal_sea_surface_height_above_mean_lower_low_water - Mean Lower Low Water - m
 """

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -34,6 +34,12 @@ pub struct YamlKnowledge {
     /// Other standards to consider
     pub related_standards: Option<Vec<String>>,
 
+    /// Standards that are usually used together
+    pub sibling_standards: Option<Vec<String>>,
+
+    /// Extra attributes that are usually included in Xarray or NetCDF metadata
+    pub extra_attrs: Option<BTreeMap<String, String>>,
+
     /// Other units that may be seen
     pub other_units: Option<Vec<String>>,
 
@@ -57,6 +63,12 @@ pub struct Knowledge {
 
     /// Other standards to consider
     pub related_standards: Vec<String>,
+
+    /// Standards that are usually used together
+    pub sibling_standards: Vec<String>,
+
+    /// Extra attributes that are usually included in Xarray or NetCDF metadata
+    pub extra_attrs: BTreeMap<String, String>,
 
     /// Other units that may be seen
     pub other_units: Vec<String>,
@@ -111,6 +123,8 @@ fn load_knowledge(path: &PathBuf) -> Knowledge {
         ioos_category: partial_knowledge.ioos_category,
         common_variable_names: partial_knowledge.common_variable_names.unwrap_or_default(),
         related_standards: partial_knowledge.related_standards.unwrap_or_default(),
+        sibling_standards: partial_knowledge.sibling_standards.unwrap_or_default(),
+        extra_attrs: partial_knowledge.extra_attrs.unwrap_or_default(),
         other_units: partial_knowledge.other_units.unwrap_or_default(),
         comments: partial_knowledge.comments,
     }

--- a/core/src/standard.rs
+++ b/core/src/standard.rs
@@ -23,6 +23,12 @@ pub struct Standard {
     /// Other standards to consider
     pub related_standards: Vec<String>,
 
+    /// Standards that are usually used together
+    pub sibling_standards: Vec<String>,
+
+    /// Extra attributes that are usually included in Xarray or NetCDF metadata
+    pub extra_attrs: BTreeMap<String, String>,
+
     /// Other units that may be seen
     pub other_units: Vec<String>,
 
@@ -62,6 +68,10 @@ impl Standard {
                 .iter()
                 .any(|name| name.to_lowercase().contains(search_str))
             || self
+                .sibling_standards
+                .iter()
+                .any(|name| name.to_lowercase().contains(search_str))
+            || self
                 .other_units
                 .iter()
                 .any(|unit| unit.to_lowercase().contains(search_str))
@@ -93,6 +103,19 @@ impl Standard {
                 self.related_standards.join(", ")
             )
         }
+        if !self.sibling_standards.is_empty() {
+            output = format!(
+                "{output}\n  Sibling standards: {}",
+                self.sibling_standards.join(", ")
+            )
+        }
+        if !self.extra_attrs.is_empty() {
+            output = format!(
+                "{output}\n  Extra attributes:\n {}",
+                self.display_xarray_attrs()
+            );
+        }
+
         if !self.other_units.is_empty() {
             output = format!("{output}\n  Other units: {}", self.other_units.join(", "))
         }
@@ -136,6 +159,10 @@ impl Standard {
             map.insert("ioos_category", ioos_category.as_str());
         }
 
+        for (key, value) in &self.extra_attrs {
+            map.insert(key, value);
+        }
+
         map
     }
 
@@ -175,6 +202,8 @@ impl fmt::Debug for Standard {
             .field("ioos_category", &self.ioos_category)
             .field("common_variable_names", &self.common_variable_names)
             .field("related_standards", &self.related_standards)
+            .field("sibling_standards", &self.sibling_standards)
+            .field("extra_attrs", &self.extra_attrs)
             .field("other_units", &self.other_units)
             .field("comments", &self.comments)
             .field("qartod", &format!("[{} test suites]", self.qartod.len()))
@@ -192,6 +221,8 @@ impl PartialEq for Standard {
             && self.ioos_category == other.ioos_category
             && self.common_variable_names == other.common_variable_names
             && self.related_standards == other.related_standards
+            && self.sibling_standards == other.sibling_standards
+            && self.extra_attrs == other.extra_attrs
             && self.other_units == other.other_units
             && self.comments == other.comments
             // Note: We compare only the length of qartod test suites since trait objects cannot be compared
@@ -200,7 +231,7 @@ impl PartialEq for Standard {
 }
 
 /// A knowledge is a subset of a Standard
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Knowledge {
     /// Standard name the knowledge applies to
     pub name: String,
@@ -216,6 +247,12 @@ pub struct Knowledge {
 
     /// Other standards to consider
     pub related_standards: Vec<String>,
+
+    /// Standards that are usually used together
+    pub sibling_standards: Vec<String>,
+
+    /// Extra attributes that are usually included in Xarray or NetCDF metadata
+    pub extra_attrs: BTreeMap<String, String>,
 
     /// Other units that may be seen
     pub other_units: Vec<String>,
@@ -239,6 +276,8 @@ mod tests {
             ioos_category: Some("Meteorology".to_string()),
             common_variable_names: Vec::new(),
             related_standards: Vec::new(),
+            sibling_standards: Vec::new(),
+            extra_attrs: BTreeMap::new(),
             other_units: Vec::new(),
             comments: None,
             qartod: Vec::new(),

--- a/core/src/standards_library.rs
+++ b/core/src/standards_library.rs
@@ -33,7 +33,7 @@ impl StandardsLibrary {
         Err("Unknown Standard")
     }
 
-    /// Returns standards that match a given column_name
+    /// Returns standards that match a given variable_name
     pub fn by_variable_name(&self, variable_name: &str) -> Vec<Standard> {
         self.standards
             .values()
@@ -88,6 +88,14 @@ impl StandardsLibrary {
                 let mut related_standards = standard.related_standards.clone();
                 related_standards.append(&mut know.related_standards.clone());
 
+                let mut sibling_standards = standard.sibling_standards.clone();
+                sibling_standards.append(&mut know.sibling_standards.clone());
+
+                let mut extra_attrs = standard.extra_attrs.clone();
+                for (key, value) in know.extra_attrs {
+                    extra_attrs.insert(key, value);
+                }
+
                 let mut other_units = standard.other_units.clone();
                 other_units.append(&mut know.other_units.clone());
 
@@ -96,6 +104,8 @@ impl StandardsLibrary {
                     ioos_category: know.ioos_category,
                     common_variable_names,
                     related_standards,
+                    sibling_standards,
+                    extra_attrs,
                     other_units: know.other_units,
                     comments: know.comments,
                     ..standard.clone()
@@ -166,11 +176,7 @@ mod tests {
         let know = Knowledge {
             name: "air_pressure_at_mean_sea_level".to_string(),
             long_name: Some("Air Pressure at Sea Level".to_string()),
-            ioos_category: None,
-            common_variable_names: Vec::new(),
-            related_standards: Vec::new(),
-            other_units: Vec::new(),
-            comments: None,
+            ..Default::default()
         };
 
         library.apply_knowledge(vec![know]);
@@ -186,17 +192,14 @@ mod tests {
     }
 
     #[test]
-    fn can_find_by_column_name() {
+    fn can_find_by_variable_name() {
         let mut library = StandardsLibrary::default();
         library.load_cf_standards();
         let know = Knowledge {
             name: "air_pressure_at_mean_sea_level".to_string(),
             long_name: Some("Air Pressure at Sea Level".to_string()),
-            ioos_category: None,
             common_variable_names: vec!["pressure".to_string()],
-            related_standards: Vec::new(),
-            other_units: Vec::new(),
-            comments: None,
+            ..Default::default()
         };
 
         library.apply_knowledge(vec![know]);

--- a/core/standards/air_pressure.yaml
+++ b/core/standards/air_pressure.yaml
@@ -1,0 +1,14 @@
+long_name: Barometric Pressure
+ioos_category: Meteorology
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: PRESSURE - BAROMETRIC
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0015
+sibling_standards:
+- air_temperature
+common_variable_names:
+- pres # codespell:ignore
+- pressure
+- barometric_pressure
+- atm_pressure
+- bpr

--- a/core/standards/air_temperature.yaml
+++ b/core/standards/air_temperature.yaml
@@ -3,7 +3,6 @@ ioos_category: Meteorology
 common_variable_names:
 - temp
 - temperature
-- temp
 - air_temp
 - airtemp
 other_units:

--- a/core/standards/air_temperature.yaml
+++ b/core/standards/air_temperature.yaml
@@ -1,8 +1,11 @@
+long_name: Air Temperature
 ioos_category: Meteorology
-common_column_names:
+common_variable_names:
 - temp
 - temperature
 - temp
+- air_temp
+- airtemp
 other_units:
 - C
 - celsius
@@ -10,7 +13,13 @@ other_units:
 - F
 - fahrenheit
 - degrees_fahrenheit
-human_description: |
+sibling_standards:
+- air_pressure
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: AIR TEMPERATURE
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0023
+comment: |
   Air temperature does what it says on the tin.
 
   Pretty much everyone actually uses celsius as a unit rather than kelvin.

--- a/core/standards/depth.yaml
+++ b/core/standards/depth.yaml
@@ -1,0 +1,7 @@
+long_name: Depth
+ioos_category: Location
+extra_attrs:
+  axis: Z
+  positive: down
+  short_name: D
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0721

--- a/core/standards/eastward_sea_water_velocity.yaml
+++ b/core/standards/eastward_sea_water_velocity.yaml
@@ -1,0 +1,15 @@
+long_name: Current U
+ioos_category: Currents
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: CURRENT METER - EAST-WEST COMPONENT
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0650
+other_units:
+- cm/s
+common_variable_names:
+- current_u
+- u
+sibling_standards:
+- sea_water_velocity_to_direction
+- sea_water_speed
+- northward_sea_water_velocity

--- a/core/standards/fluorescence_of_dissolved_organic_matter.yaml
+++ b/core/standards/fluorescence_of_dissolved_organic_matter.yaml
@@ -1,0 +1,3 @@
+long_name: Fluorescence of Dissolved Organic Matter
+common_variable_names:
+- fdom

--- a/core/standards/fractional_saturation_of_oxygen_in_sea_water.yaml
+++ b/core/standards/fractional_saturation_of_oxygen_in_sea_water.yaml
@@ -2,3 +2,6 @@ long_name: Saturated Dissolved Oxygen
 ioos_category: Dissolved O2
 common_variable_names:
 - dissolvedOxygenSaturated
+related_standards:
+- mass_concentration_of_oxygen_in_sea_water
+- mole_concentration_of_dissolved_molecular_oxygen_in_sea_water

--- a/core/standards/fractional_saturation_of_oxygen_in_sea_water.yaml
+++ b/core/standards/fractional_saturation_of_oxygen_in_sea_water.yaml
@@ -1,0 +1,4 @@
+long_name: Saturated Dissolved Oxygen
+ioos_category: Dissolved O2
+common_variable_names:
+- dissolvedOxygenSaturated

--- a/core/standards/latitude.yaml
+++ b/core/standards/latitude.yaml
@@ -1,0 +1,6 @@
+long_name: Latitude
+ioos_category: Location
+extra_attrs:
+  axis: Y
+  short_name: lat
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0600

--- a/core/standards/longitude.yaml
+++ b/core/standards/longitude.yaml
@@ -1,0 +1,6 @@
+long_name: Longitude
+ioos_category: Location
+extra_attrs:
+  axis: X
+  short_name: lon
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0554

--- a/core/standards/mass_concentration_of_chlorophyll_in_sea_water.yaml
+++ b/core/standards/mass_concentration_of_chlorophyll_in_sea_water.yaml
@@ -3,3 +3,6 @@ ioos_category: Ocean Color
 common_variable_names:
 - chlorophyll
 - chl
+other_units:
+- ug/L
+- chl/m3

--- a/core/standards/mass_concentration_of_chlorophyll_in_sea_water.yaml
+++ b/core/standards/mass_concentration_of_chlorophyll_in_sea_water.yaml
@@ -1,0 +1,5 @@
+long_name: Chlorophyll_fluorescence
+ioos_category: Ocean Color
+common_variable_names:
+- chlorophyll
+- chl

--- a/core/standards/mass_concentration_of_oxygen_in_sea_water.yaml
+++ b/core/standards/mass_concentration_of_oxygen_in_sea_water.yaml
@@ -1,0 +1,4 @@
+long_name: Mass Concentration of Dissolved Oxygen
+ioos_category: Dissolved O2
+common_variable_names:
+- dissolvedOxygenMassConcentration

--- a/core/standards/mass_concentration_of_oxygen_in_sea_water.yaml
+++ b/core/standards/mass_concentration_of_oxygen_in_sea_water.yaml
@@ -2,3 +2,6 @@ long_name: Mass Concentration of Dissolved Oxygen
 ioos_category: Dissolved O2
 common_variable_names:
 - dissolvedOxygenMassConcentration
+related_standards:
+- fractional_saturation_of_oxygen_in_sea_water
+- mole_concentration_of_dissolved_molecular_oxygen_in_sea_water

--- a/core/standards/mole_concentration_of_dissolved_molecular_oxygen_in_sea_water.yaml
+++ b/core/standards/mole_concentration_of_dissolved_molecular_oxygen_in_sea_water.yaml
@@ -5,3 +5,6 @@ extra_attrs:
 common_variable_names:
 - oxygen
 - o2
+related_standards:
+- fractional_saturation_of_oxygen_in_sea_water
+- mass_concentration_of_oxygen_in_sea_water

--- a/core/standards/mole_concentration_of_dissolved_molecular_oxygen_in_sea_water.yaml
+++ b/core/standards/mole_concentration_of_dissolved_molecular_oxygen_in_sea_water.yaml
@@ -1,0 +1,7 @@
+ioos_category: Dissolved O2
+long_name: Oxygen
+extra_attrs:
+  nodc_name: OXYGEN
+common_variable_names:
+- oxygen
+- o2

--- a/core/standards/mole_concentration_of_nitrate_in_sea_water.yaml
+++ b/core/standards/mole_concentration_of_nitrate_in_sea_water.yaml
@@ -1,0 +1,4 @@
+long_name: Mole Concentration of Nitrate
+ioos_category: Dissolved Nutrients
+common_variable_names:
+- nitrate

--- a/core/standards/mole_fraction_carbon_dioxide_in_water.yaml
+++ b/core/standards/mole_fraction_carbon_dioxide_in_water.yaml
@@ -1,0 +1,2 @@
+long_name: Mole Fraction of Carbon Dioxide in Water
+ioos_category: CO2

--- a/core/standards/northward_sea_water_velocity.yaml
+++ b/core/standards/northward_sea_water_velocity.yaml
@@ -1,0 +1,15 @@
+long_name: Current V
+ioos_category: Currents
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: CURRENT METER - NORTH-SOUTH COMPONENT
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFS0494
+common_variable_names:
+- current_v
+- v
+sibling_standards:
+- sea_water_velocity_to_direction
+- sea_water_speed
+- eastward_sea_water_velocity
+other_units:
+- cm/s

--- a/core/standards/sea_surface_height_above_geopotential_datum.yaml
+++ b/core/standards/sea_surface_height_above_geopotential_datum.yaml
@@ -1,1 +1,5 @@
 ioos_category: Sea Level
+long_name: Sea surface height above geopotential datum
+sibling_standards:
+- tidal_sea_surface_height_above_mean_lower_low_water
+- tidal_sea_surface_height_above_mean_higher_high_water

--- a/core/standards/sea_surface_wave_directional_spread_at_variance_spectral_density_maximum.yaml
+++ b/core/standards/sea_surface_wave_directional_spread_at_variance_spectral_density_maximum.yaml
@@ -1,0 +1,15 @@
+long_name: Mean Wave Direction Spreading
+ioos_category: Surface Waves
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WAVE DIRECTION - SPREAD
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/X37RPE7M
+common_variable_names:
+- mean_wave_direction_spread
+- mwds
+- peakDirectionalSpread
+sibling_standards:
+- sea_surface_wave_significant_height
+- sea_surface_wave_period_at_variance_spectral_density_maximum
+- sea_surface_wave_maximum_height
+- sea_surface_wave_from_direction

--- a/core/standards/sea_surface_wave_from_direction.yaml
+++ b/core/standards/sea_surface_wave_from_direction.yaml
@@ -1,0 +1,16 @@
+long_name: Mean Wave Direction
+ioos_category: Surface Waves
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WAVE DIRECTION - Average
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSM0384
+common_variable_names:
+- wave_direction
+- direction
+- mwd
+- mean_wave_direction
+sibling_standards:
+- sea_surface_wave_significant_height
+- sea_surface_wave_period_at_variance_spectral_density_maximum
+- sea_surface_wave_maximum_height
+- sea_surface_wave_directional_spread_at_variance_spectral_density_maximum

--- a/core/standards/sea_surface_wave_maximum_height.yaml
+++ b/core/standards/sea_surface_wave_maximum_height.yaml
@@ -1,0 +1,16 @@
+long_name: Maximum Wave Height
+ioos_category: Surface Waves
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WAVE HEIGHT - MAXIMUM
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/NQS0CMX
+common_variable_names:
+- wave_height_maximum
+- height_maximum
+- mwh
+- max_wave_height
+sibling_standards:
+- sea_surface_wave_significant_height
+- sea_surface_wave_period_at_variance_spectral_density_maximum
+- sea_surface_wave_from_direction
+- sea_surface_wave_directional_spread_at_variance_spectral_density_maximum

--- a/core/standards/sea_surface_wave_mean_period.yaml
+++ b/core/standards/sea_surface_wave_mean_period.yaml
@@ -1,0 +1,4 @@
+long_name: Mean Wave Period
+ioos_category: Surface Waves
+common_variable_names:
+- meanPeriod

--- a/core/standards/sea_surface_wave_period_at_variance_spectral_density_maximum.yaml
+++ b/core/standards/sea_surface_wave_period_at_variance_spectral_density_maximum.yaml
@@ -1,0 +1,17 @@
+long_name: Dominant Wave Period
+ioos_category: Surface Waves
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WAVE PERIOD - DOMINANT
+  standard_name_url: vocab.nerc.ac.uk/collection/P07/current/CFV13N31
+common_variable_names:
+- wave_period
+- period
+- dominant_wave_period
+- dwp
+- peakPeriod
+sibling_standards:
+- sea_surface_wave_significant_height
+- sea_surface_wave_maximum_height
+- sea_surface_wave_from_direction
+- sea_surface_wave_directional_spread_at_variance_spectral_density_maximum

--- a/core/standards/sea_surface_wave_significant_height.yaml
+++ b/core/standards/sea_surface_wave_significant_height.yaml
@@ -1,0 +1,18 @@
+long_name: Significant Wave Height
+ioos_category: Surface Waves
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WAVE HEIGHT - SIGNIFICANT
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0385
+common_variable_names:
+- wave_height
+- height
+- swh
+- significant_wave_height
+- hs
+- significantWaveHeight
+sibling_standards:
+- sea_surface_wave_period_at_variance_spectral_density_maximum
+- sea_surface_wave_maximum_height
+- sea_surface_wave_from_direction
+- sea_surface_wave_directional_spread_at_variance_spectral_density_maximum

--- a/core/standards/sea_water_density.yaml
+++ b/core/standards/sea_water_density.yaml
@@ -1,0 +1,13 @@
+long_name: Sigma-T (Density)
+ioos_category: Physical Oceanography
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: DENSITY
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0332
+common_variable_names:
+- sigt
+- sigma_t
+sibling_standards:
+- sea_water_practical_salinity
+- sea_water_electrical_conductivity
+- sea_water_temperature

--- a/core/standards/sea_water_electrical_conductivity.yaml
+++ b/core/standards/sea_water_electrical_conductivity.yaml
@@ -1,0 +1,14 @@
+long_name: Conductivity
+ioos_category: Salinity
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WATER CONDUCTIVITY
+  nodc_name: SALINITY
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0394
+common_variable_names:
+- conductivity
+- cond
+sibling_standards:
+- sea_water_practical_salinity
+- sea_water_density
+- sea_water_temperature

--- a/core/standards/sea_water_electrical_conductivity.yaml
+++ b/core/standards/sea_water_electrical_conductivity.yaml
@@ -1,9 +1,8 @@
 long_name: Conductivity
-ioos_category: Salinity
+ioos_category: Physical Oceanography
 extra_attrs:
   coverage_content_type: physicalMeasurement
   ncei_name: WATER CONDUCTIVITY
-  nodc_name: SALINITY
   standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0394
 common_variable_names:
 - conductivity

--- a/core/standards/sea_water_ph_reported_on_total_scale.yaml
+++ b/core/standards/sea_water_ph_reported_on_total_scale.yaml
@@ -1,0 +1,2 @@
+ioos_category: CO2
+long_name: Sea Water pH

--- a/core/standards/sea_water_practical_salinity.yaml
+++ b/core/standards/sea_water_practical_salinity.yaml
@@ -4,7 +4,7 @@ extra_attrs:
   coverage_content_type: physicalMeasurement
   ncei_name: SALINITY
   nodc_name: SALINITY
-  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0331
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/IADIHDIJ/
 common_variable_names:
 - sal
 - salinity
@@ -12,3 +12,6 @@ sibling_standards:
 - sea_water_electrical_conductivity
 - sea_water_density
 - sea_water_temperature
+other_units:
+- ppt
+- psu

--- a/core/standards/sea_water_practical_salinity.yaml
+++ b/core/standards/sea_water_practical_salinity.yaml
@@ -1,0 +1,14 @@
+long_name: Salinity
+ioos_category: Salinity
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: SALINITY
+  nodc_name: SALINITY
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0331
+common_variable_names:
+- sal
+- salinity
+sibling_standards:
+- sea_water_electrical_conductivity
+- sea_water_density
+- sea_water_temperature

--- a/core/standards/sea_water_speed.yaml
+++ b/core/standards/sea_water_speed.yaml
@@ -1,0 +1,13 @@
+long_name: Current Speed
+ioos_category: Currents
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: CURRENT METER - SPEED
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0334
+common_variable_names:
+- current_speed
+- cspd
+sibling_standards:
+- sea_water_velocity_to_direction
+- eastward_sea_water_velocity
+- northward_sea_water_velocity

--- a/core/standards/sea_water_temperature.yaml
+++ b/core/standards/sea_water_temperature.yaml
@@ -1,0 +1,14 @@
+long_name: Water Temperature
+ioos_category: Temperature
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WATER TEMPERATURE
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0335
+common_variable_names:
+- temperature
+- temp
+- wt
+sibling_standards:
+- sea_water_practical_salinity
+- sea_water_electrical_conductivity
+- sea_water_density

--- a/core/standards/sea_water_turbidity.yaml
+++ b/core/standards/sea_water_turbidity.yaml
@@ -1,0 +1,4 @@
+long_name: Turbidity
+common_variable_names:
+- turbidity
+- ntu

--- a/core/standards/sea_water_turbidity.yaml
+++ b/core/standards/sea_water_turbidity.yaml
@@ -1,4 +1,9 @@
 long_name: Turbidity
+extra_attrs:
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/7B3X6L2J/
 common_variable_names:
 - turbidity
 - ntu
+other_units:
+- ntu
+- ftu

--- a/core/standards/sea_water_velocity_to_direction.yaml
+++ b/core/standards/sea_water_velocity_to_direction.yaml
@@ -1,0 +1,13 @@
+long_name: Current Direction
+ioos_category: Currents
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: CURRENT METER - DIRECTION
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/5D4D7YMF
+common_variable_names:
+- current_direction
+- cdir
+sibling_standards:
+- sea_water_speed
+- eastward_sea_water_velocity
+- northward_sea_water_velocity

--- a/core/standards/tidal_sea_surface_height_above_mean_higher_high_water.yaml
+++ b/core/standards/tidal_sea_surface_height_above_mean_higher_high_water.yaml
@@ -1,0 +1,5 @@
+ioos_category: Sea Level
+long_name: Mean Higher High Water
+sibling_standards:
+- tidal_sea_surface_height_above_mean_lower_low_water
+- sea_surface_height_above_geopotential_datum

--- a/core/standards/tidal_sea_surface_height_above_mean_lower_low_water.yaml
+++ b/core/standards/tidal_sea_surface_height_above_mean_lower_low_water.yaml
@@ -1,0 +1,5 @@
+ioos_category: Sea Level
+long_name: Mean Lower Low Water
+sibling_standards:
+- tidal_sea_surface_height_above_mean_higher_high_water
+- sea_surface_height_above_geopotential_datum

--- a/core/standards/time.yaml
+++ b/core/standards/time.yaml
@@ -1,0 +1,5 @@
+long_name: Time
+ioos_category: Time
+extra_attrs:
+  axis: T
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0115

--- a/core/standards/visibility_in_air.yaml
+++ b/core/standards/visibility_in_air.yaml
@@ -1,0 +1,8 @@
+long_name: Visibility in Air
+ioos_category: Meteorology
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: VISIBILITY
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0061
+common_variable_names:
+- visibility

--- a/core/standards/wind_from_direction.yaml
+++ b/core/standards/wind_from_direction.yaml
@@ -1,0 +1,13 @@
+long_name: Wind From Direction
+ioos_category: Meteorology
+sibling_standards:
+- wind_speed_of_gust
+- wind_speed
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WIND DIRECTION
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0036
+common_variable_names:
+- wdir
+- dir
+- wind_direction

--- a/core/standards/wind_speed.yaml
+++ b/core/standards/wind_speed.yaml
@@ -1,0 +1,11 @@
+long_name: Wind Speed
+ioos_category: Meteorology
+sibling_standards:
+- wind_speed_of_gust
+- wind_from_direction
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WIND SPEED
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0038
+common_variable_names:
+- wspd

--- a/core/standards/wind_speed_of_gust.yaml
+++ b/core/standards/wind_speed_of_gust.yaml
@@ -1,0 +1,12 @@
+long_name: Wind Speed of Gust
+ioos_category: Meteorology
+sibling_standards:
+- wind_speed
+- wind_from_direction
+extra_attrs:
+  coverage_content_type: physicalMeasurement
+  ncei_name: WIND GUST
+  standard_name_url: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0039
+common_variable_names:
+- gust
+- wgst

--- a/py/src/standards_library.rs
+++ b/py/src/standards_library.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use pyo3::{exceptions::PyKeyError, prelude::*};
 
@@ -90,6 +90,8 @@ impl PyStandardsLibrary {
 
             let common_variable_names = get_list_field(&know, "common_variable_names")?;
             let related_standards = get_list_field(&know, "related_standards")?;
+            let sibling_standards = get_list_field(&know, "sibling_standards")?;
+            let extra_attrs = get_dict_field(&know, "extra_attrs")?;
             let other_units = get_list_field(&know, "other_units")?;
 
             let cleaned = Knowledge {
@@ -98,6 +100,8 @@ impl PyStandardsLibrary {
                 ioos_category,
                 common_variable_names,
                 related_standards,
+                sibling_standards,
+                extra_attrs,
                 other_units,
                 comments,
             };
@@ -119,6 +123,7 @@ impl PyStandardsLibrary {
 enum KnowledgeValues {
     String(String),
     List(Vec<String>),
+    Dict(BTreeMap<String, String>),
 }
 
 fn get_string_field(
@@ -144,5 +149,18 @@ fn get_list_field(
             "`{key}` must be a list of strings"
         ))),
         None => Ok(Vec::new()),
+    }
+}
+
+fn get_dict_field(
+    knowledge: &HashMap<String, KnowledgeValues>,
+    key: &str,
+) -> PyResult<BTreeMap<String, String>> {
+    match knowledge.get(key) {
+        Some(KnowledgeValues::Dict(dict_value)) => Ok(dict_value.clone()),
+        Some(_) => Err(PyKeyError::new_err(format!(
+            "`{key}` must be a dictionary of strings"
+        ))),
+        None => Ok(BTreeMap::new()),
     }
 }


### PR DESCRIPTION
Adding many more of the standards that we’ve seen on NERACOOS servers, 
and in the process realizing that there are a few other ways and bits of
data we may want to store with knowledge.

`sibling_standards` is for standards that are most commonly seen 
together, as usually they come from the same suite of sensors.

`extra_attrs` is additional attributes like NDBC names that we may want 
to add to a dataset.