### PR TITLE
JS preview - query and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ standards = library.filter().by_variable_name("pressure")
 under_pressure = library.filter().search("pressure")
 ```
 
-Or in Javascript
+Or in Javascript ([preview here!](https://gulfofmaine.github.io/standard_knowledge/))
 
 ```js
 import init, { StandardsLibrary } from "./pkg/standard_knowledge_js.js"

--- a/core/src/standards_library.rs
+++ b/core/src/standards_library.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::qartod::StaticQcTestSuite;
 use crate::standards_filter::StandardsFilter;
@@ -97,6 +97,14 @@ impl StandardsLibrary {
                 self.standards.insert(name, new_standard);
             }
         }
+    }
+
+    /// Return a set of all known IOOS categories
+    pub fn known_ioos_categories(&self) -> HashSet<String> {
+        self.standards
+            .values()
+            .flat_map(|s| s.ioos_category.clone())
+            .collect()
     }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -25,10 +25,9 @@ class Standard extends HTMLElement {
 
         this.innerHTML = `
             <div class="accordion-item">
-                <h2 class="accordion-header">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse${this.#standard.name}" aria-expanded="${this.#show}" aria-controls="collapse${this.#standard.name}">
-                ${this.#standard.long_name ? this.#standard.long_name + " - " : ""} ${this.#standard.name}</button>
-                </h2>
+                <h4 class="accordion-header bg-primary-subtle">
+                ${this.#standard.name}
+                </h4>
                 <div id="collapse${this.#standard.name}" class="accordion-collapse show" aria-labelledby="heading${this.#standard.name}" data-bs-parent="#accordionExample">
                     <div class="accordion-body">
                         <table class="table">
@@ -98,6 +97,50 @@ class Standard extends HTMLElement {
 
 customElements.define("x-standard", Standard);
 
+class GetStandard extends HTMLElement {
+    connectedCallback() {
+        this.innerHTML = `
+        <div class="card">
+            <div class="card-header">
+                <h2>Get knowledge about a standard</h2>
+                <form>
+                    <input type="text" id="name" name="name" placeholder="Enter a CF standard name" />
+                    <button type="submit">Show Standard</button>
+                </form>
+            </div>
+            <div class="card-body" id="result">
+                Please enter a standard
+            </div>
+        </div>
+        `
+
+        this.querySelector("form").onsubmit = (e) => {
+            e.preventDefault();
+            const data = new FormData(e.target)
+            const name = data.get("name").toString().trim();
+
+            if (name) {
+                try {
+                    let standard = this.library.get(name); // Just to see if it exists
+                    this.querySelector("#result").innerHTML = `
+                        <x-standard></x-standard>
+                    `;
+                    this.querySelector("x-standard").standard = standard;
+                } catch (error) {
+                    this.querySelector("#result").innerHTML = `
+                    <div class="alert alert-danger" role="alert">
+                        Could not find standard with name <strong>${name}</strong>
+                    </div>
+                    `
+                    console.error(error);
+                }
+            }
+        }
+    }
+}
+
+customElements.define("x-get-standard", GetStandard);
+
 class App extends HTMLElement {
     connectedCallback() {
         this.textContent = "Invalid standard"
@@ -108,24 +151,22 @@ class App extends HTMLElement {
         this.library.loadTestSuites();
 
         this.innerHTML = `
-        <div class="accordion">
-            <x-standard></x-standard>
-        </div>
+        <x-get-standard></x-get-standard>
         `;
 
-        try {
-            // let standard = this.library.get("air_temperature")
-            // let standard = this.library.get("air_pressure_at_mean_sea_level")
-            let standard = this.library.get("sea_surface_height_above_geopotential_datum")
-            console.log(standard.attrs())
+        this.querySelector("x-get-standard").library = this.library;
 
-            this.querySelector("x-standard").standard = standard;
-            this.querySelector("x-standard").show = true;
-        } catch (error) {
-            console.error(error)
-        }
+        // try {
+        //     // let standard = this.library.get("air_temperature")
+        //     // let standard = this.library.get("air_pressure_at_mean_sea_level")
+        //     let standard = this.library.get("sea_surface_height_above_geopotential_datum")
+        //     // console.log(standard.attrs())
 
-        // debugger
+        //     // this.querySelector("x-standard").standard = standard;
+        //     this.querySelector("x-standard").show = true;
+        // } catch (error) {
+        //     console.error(error)
+        // }
     }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -24,71 +24,71 @@ class Standard extends HTMLElement {
         }
 
         this.innerHTML = `
-            <div class="accordion-item">
-                <h4 class="accordion-header bg-primary-subtle">
-                ${this.#standard.name}
-                </h4>
-                <div id="collapse${this.#standard.name}" class="accordion-collapse show" aria-labelledby="heading${this.#standard.name}" data-bs-parent="#accordionExample">
-                    <div class="accordion-body">
-                        <table class="table">
-                            <tr class="table-primary">
-                                <td>Unit</td>
-                                <td>${this.#standard.unit}</td>
-                            </tr>
-                            <tr class="table-primary">
-                                <td>Aliases</td>
-                                <td>${this.#standard.aliases.join(", ")}</td>
-                            </tr>
-                            <tr title="A more human readable name for the standard">
-                                <td>Long Name</td>
-                                <td>${this.#standard.longName}</td>
-                            </tr>
-                            <tr title="Category of measurement for the Integrated Ocean Observing System">
-                                <td>IOOS Category</td>
-                                <td>${this.#standard.ioosCategory}</td>
-                            </tr>
-                            <tr title="When the standard name isn't used for a column or variable, what might commonly get used instead.">
-                                <td>Common variable names</td>
-                                <td>${this.#standard.commonVariableNames.join(", ")}</td>
-                            </tr>
-                            <tr title="Standards that are usually used together">
-                                <td>Sibling Standards</td>
-                                <td>${this.#standard.siblingStandards.join(", ")}</td>
-                            </tr>
-                            <tr title="Standards that measure generally similar things, but differ in specifics that are worth investigating.">
-                                <td>Related standards</td>
-                                <td>${this.#standard.relatedStandards.join(", ")}</td>
-                            </tr>
-                            <tr title="Other units that may be used rather than the one defined in the standard.">
-                                <td>Other Units</td>
-                                <td>${this.#standard.otherUnits.join(", ")}</td>
-                            </tr>
-                        </table>
+            <div class="card">
+                <div class="card-header bg-primary-subtle">
+                    <h4>
+                        ${this.#standard.name}
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <table class="table">
+                        <tr class="table-primary">
+                            <td>Unit</td>
+                            <td>${this.#standard.unit}</td>
+                        </tr>
+                        <tr class="table-primary">
+                            <td>Aliases</td>
+                            <td>${this.#standard.aliases.join(", ")}</td>
+                        </tr>
+                        <tr title="A more human readable name for the standard">
+                            <td>Long Name</td>
+                            <td>${this.#standard.longName}</td>
+                        </tr>
+                        <tr title="Category of measurement for the Integrated Ocean Observing System">
+                            <td>IOOS Category</td>
+                            <td>${this.#standard.ioosCategory}</td>
+                        </tr>
+                        <tr title="When the standard name isn't used for a column or variable, what might commonly get used instead.">
+                            <td>Common variable names</td>
+                            <td>${this.#standard.commonVariableNames.join(", ")}</td>
+                        </tr>
+                        <tr title="Standards that are usually used together">
+                            <td>Sibling Standards</td>
+                            <td>${this.#standard.siblingStandards.join(", ")}</td>
+                        </tr>
+                        <tr title="Standards that measure generally similar things, but differ in specifics that are worth investigating.">
+                            <td>Related standards</td>
+                            <td>${this.#standard.relatedStandards.join(", ")}</td>
+                        </tr>
+                        <tr title="Other units that may be used rather than the one defined in the standard.">
+                            <td>Other Units</td>
+                            <td>${this.#standard.otherUnits.join(", ")}</td>
+                        </tr>
+                    </table>
 
-                        <div class="bg-primary-subtle">
-                        <h4>Description:</h4>
-                        <p>${this.#standard.description}</p>
-                        </div>
-
-                        ${attrs.length === 0 ? "<p>No attributes</p>" : `
-                            <h4>Suggested attributes:</h4>
-                            <code>
-                                ${JSON.stringify(mapToObj(this.#standard.attrs()), null, 2)}
-                            </code>
-                        `}
-
-                        ${this.#standard.comments ? `
-                            <h4>Comments:</h4>
-                            <p>${this.#standard.comments}</p>
-                        ` : ""}
-
-                        ${this.#standard.qartod.length > 0 ? `
-                            <h4>QARTOD Tests:</h4>
-                            <ul>
-                                ${this.#standard.qartod.map(q => `<li>${q.name} (<code>${q.slug}</code>) <p>${q.description}</p></li>`).join("")}
-                            </ul>
-                        ` : ""}
+                    <div class="bg-primary-subtle">
+                    <h4>Description:</h4>
+                    <p>${this.#standard.description}</p>
                     </div>
+
+                    ${attrs.length === 0 ? "<p>No attributes</p>" : `
+                        <h4>Suggested attributes:</h4>
+                        <code>
+                            ${JSON.stringify(mapToObj(this.#standard.attrs()), null, 2)}
+                        </code>
+                    `}
+
+                    ${this.#standard.comments ? `
+                        <h4>Comments:</h4>
+                        <p>${this.#standard.comments}</p>
+                    ` : ""}
+
+                    ${this.#standard.qartod.length > 0 ? `
+                        <h4>QARTOD Tests:</h4>
+                        <ul>
+                            ${this.#standard.qartod.map(q => `<li>${q.name} (<code>${q.slug}</code>) <p>${q.description}</p></li>`).join("")}
+                        </ul>
+                    ` : ""}
                 </div>
             </div>
         `;
@@ -97,19 +97,156 @@ class Standard extends HTMLElement {
 
 customElements.define("x-standard", Standard);
 
+class FilterStandards extends HTMLElement {
+    varName = ""
+    ioosCategory = ""
+    unit = ""
+    qartodTests = false
+    search = ""
+
+    connectedCallback() {
+        this.innerHTML = `
+            <div class="accordion-item">
+                <div class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFilter" aria-expanded="true" aria-controls="collapseFilter">
+                        <h2>Filter standards</h2>
+                    </button>
+                </div>
+                <div id="collapseFilter" class="accordion-collapse collapse show">
+                    <div class="accordion-body">
+                        <div class="mb-3">
+                            <label for="varName">By common variable names</label>
+                            <input type="text" id="varName" name="varName" placeholder="Filter by common variable names" />
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="ioosCategory">By IOOS Category</label>
+                            <input type="text" id="ioosCategory" name="ioosCategory" placeholder="Filter by IOOS Category" />
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="unit">By Unit</label>
+                            <input type="text" id="unit" name="unit" placeholder="Filter by Unit" />
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="qartodTests">By QARTOD Tests</label>
+                            <input type="checkbox" id="qartodTests" name="qartodTests" />
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="search">Text Search</label>
+                            <input type="text" id="search" name="search" placeholder="Filter by Search" />
+                        </div>
+
+                        <div id="filterResult">
+                            Please enter a keyword
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        this.querySelector("#varName").addEventListener("input", (e) => {
+            this.varName = e.target.value;
+            this.update()
+        });
+
+        this.querySelector("#ioosCategory").addEventListener("input", (e) => {
+            this.ioosCategory = e.target.value;
+            this.update();
+        });
+
+        this.querySelector("#unit").addEventListener("input", (e) => {
+            this.unit = e.target.value;
+            this.update();
+        });
+
+        this.querySelector("#qartodTests").addEventListener("change", (e) => {
+            this.qartodTests = e.target.checked;
+            this.update();
+        });
+
+        this.querySelector("#search").addEventListener("input", (e) => {
+            this.search = e.target.value;
+            this.update();
+        });
+    }
+
+    update() {
+        let filter = this.library.filter()
+
+        if (this.varName) {
+            filter = filter.byVariableName(this.varName)
+        }
+
+        if (this.ioosCategory) {
+            filter = filter.byIoosCategory(this.ioosCategory)
+        }
+
+        if (this.unit) {
+            filter = filter.byUnit(this.unit)
+        }
+
+        if (this.qartodTests) {
+            filter = filter.hasQartodTests(this.qartodTests)
+        }
+
+        if (this.search) {
+            filter = filter.search(this.search)
+        }
+
+        let standards = filter.standards
+
+        if (standards.length === this.library.filter().standards.length) {
+            this.querySelector("#filterResult").innerHTML = `
+                <div class="alert alert-info" role="alert">
+                    Please enter filters
+                </div>
+            `;
+        } else if (standards.length === 0) {
+            this.querySelector("#filterResult").innerHTML = `
+                <div class="alert alert-warning" role="alert">
+                    No standards found
+                </div>
+            `;
+        } else {
+            this.querySelector("#filterResult").innerHTML = `
+                <ul>
+                    ${standards.map(s => {
+                        if (s.longName) {
+                            return `<li>${s.longName} - <span class="bg-primary-subtle">${s.name}</span></li>`;
+                        }
+
+                        return `<li><span class="bg-primary-subtle">${s.name}</span></li>`;
+                    }).join("")}
+                </ul>
+            `;
+        }
+    }
+}
+
+customElements.define("x-filter-standards", FilterStandards);
+
 class GetStandard extends HTMLElement {
     connectedCallback() {
         this.innerHTML = `
-        <div class="card">
-            <div class="card-header">
-                <h2>Get knowledge about a standard</h2>
-                <form>
-                    <input type="text" id="name" name="name" placeholder="Enter a CF standard name" />
-                    <button type="submit">Show Standard</button>
-                </form>
+        <div class="accordion-item">
+            <div class="accordion-header">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGet" aria-expanded="true" aria-controls="collapseGet">
+                    <h2>Get knowledge about a standard</h2>
+                </button>
             </div>
-            <div class="card-body" id="result">
-                Please enter a standard
+            <div id="collapseGet" class="accordion-collapse collapse show">
+                <div class="accordion-body">
+                    <form>
+                        <input type="text" id="name" name="name" placeholder="Enter a CF standard name" />
+                        <button type="submit">Show Standard</button>
+                    </form>
+                    <div id="result">
+                        Please enter a standard
+                    </div>
+                </div>
             </div>
         </div>
         `
@@ -151,22 +288,14 @@ class App extends HTMLElement {
         this.library.loadTestSuites();
 
         this.innerHTML = `
-        <x-get-standard></x-get-standard>
+        <div class="accordion">
+            <x-filter-standards></x-filter-standards>
+            <x-get-standard></x-get-standard>
+        </div>
         `;
 
         this.querySelector("x-get-standard").library = this.library;
-
-        // try {
-        //     // let standard = this.library.get("air_temperature")
-        //     // let standard = this.library.get("air_pressure_at_mean_sea_level")
-        //     let standard = this.library.get("sea_surface_height_above_geopotential_datum")
-        //     // console.log(standard.attrs())
-
-        //     // this.querySelector("x-standard").standard = standard;
-        //     this.querySelector("x-standard").show = true;
-        // } catch (error) {
-        //     console.error(error)
-        // }
+        this.querySelector("x-filter-standards").library = this.library;
     }
 }
 

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -184,7 +184,7 @@ pub struct StandardsFilterJS {
 
 #[wasm_bindgen]
 impl StandardsFilterJS {
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = byVariableName)]
     pub fn by_variable_name(self, variable_name: &str) -> Self {
         let filtered = self
             .standards
@@ -201,7 +201,7 @@ impl StandardsFilterJS {
         }
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = byIoosCategory)]
     pub fn by_ioos_category(self, category: &str) -> Self {
         let filtered = self
             .standards
@@ -218,7 +218,7 @@ impl StandardsFilterJS {
         }
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = byUnit)]
     pub fn by_unit(self, unit: &str) -> Self {
         let filtered = self
             .standards
@@ -231,7 +231,7 @@ impl StandardsFilterJS {
         }
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = hasQartodTests)]
     pub fn has_qartod_tests(self) -> Self {
         let filtered = self
             .standards
@@ -257,12 +257,14 @@ impl StandardsFilterJS {
         }
     }
 
-    // #[wasm_bindgen]
-    // pub fn get_standards(&self) -> JsValue {
-    //     let js_standards = self.standards.iter()
-    //         .map(|s| StandardJS { inner: s.clone() })
-    //         .collect::<Vec<_>>();
+    #[wasm_bindgen(getter)]
+    pub fn standards(&self) -> Vec<StandardJS> {
+        let js_standards = self
+            .standards
+            .iter()
+            .map(|s| StandardJS { inner: s.clone() })
+            .collect::<Vec<_>>();
 
-    //     to_value(&js_standards).unwrap_or(JsValue::NULL)
-    // }
+        js_standards
+    }
 }

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -52,6 +52,11 @@ impl StandardsLibraryJS {
             standards: self.inner.filter().standards.into_iter().cloned().collect(),
         }
     }
+
+    #[wasm_bindgen(js_name = knownIoosCategories)]
+    pub fn known_ioos_categories(&self) -> Vec<String> {
+        self.inner.known_ioos_categories().into_iter().collect()
+    }
 }
 
 #[derive(Clone)]

--- a/py/src/standards_library.rs
+++ b/py/src/standards_library.rs
@@ -116,6 +116,11 @@ impl PyStandardsLibrary {
         let py_filter = crate::PyStandardsFilter::from(filter);
         Py::new(py, py_filter)
     }
+
+    /// Return known IOOS Categories
+    fn known_ioos_categories(&self) -> Vec<String> {
+        self.0.known_ioos_categories().into_iter().collect()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Allow querying by standard name in the Javascript Github Pages preview, and filtering by various knowledge.

<img width="755" height="794" alt="image" src="https://github.com/user-attachments/assets/c5110fa3-fb5f-4813-a96f-55c0737217e8" />
