### PR TITLE
Simplify filters

### DIFF
--- a/cli/src/filter.rs
+++ b/cli/src/filter.rs
@@ -31,7 +31,7 @@ enum ListFormat {
 }
 
 impl ListFormat {
-    fn format_standards(&self, standards: Vec<&Standard>) -> String {
+    fn format_standards(&self, standards: Vec<Standard>) -> String {
         match self {
             Self::Short => standards
                 .iter()

--- a/core/src/standards_filter.rs
+++ b/core/src/standards_filter.rs
@@ -4,11 +4,11 @@ use crate::standard::Standard;
 
 /// Chainable filter for standards
 #[derive(Clone)]
-pub struct StandardsFilter<'a> {
-    pub standards: Vec<&'a Standard>,
+pub struct StandardsFilter {
+    pub standards: Vec<Standard>,
 }
 
-impl<'a> StandardsFilter<'a> {
+impl StandardsFilter {
     /// Return a standard by name or alias
     pub fn get(&self, standard_name_or_alias: &str) -> Result<&Standard, &'static str> {
         for standard in &self.standards {
@@ -24,74 +24,78 @@ impl<'a> StandardsFilter<'a> {
     }
 
     /// Returns standards by common variable name
-    pub fn by_variable_name(self, variable_name: &str) -> Self {
-        let mut standards: Vec<&Standard> = self
+    pub fn by_variable_name(&self, variable_name: &str) -> Self {
+        let mut standards: Vec<Standard> = self
             .standards
-            .into_iter()
+            .iter()
             .filter(|standard| {
                 standard
                     .common_variable_names
                     .iter()
                     .any(|name| name == variable_name)
             })
+            .cloned()
             .collect();
         standards.sort_by_key(|s| s.name.clone());
         StandardsFilter { standards }
     }
 
     /// Returns standards by IOOS category
-    pub fn by_ioos_category(self, category: &str) -> Self {
-        let mut standards: Vec<&Standard> = self
+    pub fn by_ioos_category(&self, category: &str) -> Self {
+        let mut standards: Vec<Standard> = self
             .standards
-            .into_iter()
+            .iter()
             .filter(|standard| {
                 standard
                     .ioos_category
                     .as_ref()
                     .is_some_and(|cat| cat.eq_ignore_ascii_case(category))
             })
+            .cloned()
             .collect();
         standards.sort_by_key(|s| s.name.clone());
         StandardsFilter { standards }
     }
 
     /// Returns standards for a given unit
-    pub fn by_unit(self, unit: &str) -> Self {
-        let mut standards: Vec<&'a Standard> = self
+    pub fn by_unit(&self, unit: &str) -> Self {
+        let mut standards: Vec<Standard> = self
             .standards
-            .into_iter()
+            .iter()
             .filter(|standard| {
                 standard.unit == unit || standard.other_units.iter().any(|u| u == unit)
             })
+            .cloned()
             .collect();
         standards.sort_by_key(|s| s.name.clone());
         StandardsFilter { standards }
     }
 
     /// Returns standards that have QARTOD tests
-    pub fn has_qartod_tests(self) -> Self {
-        let mut standards: Vec<&Standard> = self
+    pub fn has_qartod_tests(&self) -> Self {
+        let mut standards: Vec<Standard> = self
             .standards
-            .into_iter()
+            .iter()
             .filter(|standard| !standard.qartod.is_empty())
+            .cloned()
             .collect();
         standards.sort_by_key(|s| s.name.clone());
         StandardsFilter { standards }
     }
 
     /// Returns standards that match a search pattern
-    pub fn search(self, search_str: &str) -> Self {
+    pub fn search(&self, search_str: &str) -> Self {
         let mut search_index: SearchIndex<usize> = SearchIndex::default();
 
         self.standards
             .iter()
             .enumerate()
-            .for_each(|(index, element)| search_index.insert(&index, *element));
+            .for_each(|(index, element)| search_index.insert(&index, element));
         let results = search_index.search(search_str);
 
-        let mut standards: Vec<&Standard> = Vec::new();
+        let mut standards: Vec<Standard> = Vec::new();
         for index in results {
-            standards.push(self.standards[*index]);
+            standards.push(self.standards[*index].clone());
         }
 
         standards.sort_by_key(|s| s.name.clone());

--- a/core/src/standards_library.rs
+++ b/core/src/standards_library.rs
@@ -19,7 +19,7 @@ impl StandardsLibrary {
 
     pub fn filter(&self) -> StandardsFilter {
         StandardsFilter {
-            standards: self.standards.values().collect(),
+            standards: self.standards.values().cloned().collect(),
         }
     }
 

--- a/py/src/standards_filter.rs
+++ b/py/src/standards_filter.rs
@@ -1,25 +1,20 @@
 use std::convert::From;
 
-use indicium::simple::SearchIndex;
 use pyo3::exceptions::{PyIndexError, PyKeyError};
 use pyo3::prelude::*;
 
 use crate::PyStandard;
-
-use standard_knowledge::Standard;
 use standard_knowledge::standards_filter::StandardsFilter;
 
 #[pyclass(name = "StandardsFilter")]
 #[derive(Clone)]
 pub struct PyStandardsFilter {
-    pub standards: Vec<Standard>,
+    inner: StandardsFilter,
 }
 
-impl From<StandardsFilter<'_>> for PyStandardsFilter {
+impl From<StandardsFilter> for PyStandardsFilter {
     fn from(filter: StandardsFilter) -> Self {
-        PyStandardsFilter {
-            standards: filter.standards.into_iter().cloned().collect(),
-        }
+        PyStandardsFilter { inner: filter }
     }
 }
 
@@ -27,107 +22,49 @@ impl From<StandardsFilter<'_>> for PyStandardsFilter {
 impl PyStandardsFilter {
     /// Return standards by common variable name
     fn by_variable_name(&self, py: Python, variable_name: &str) -> PyResult<Py<PyStandardsFilter>> {
-        let standards = self
-            .standards
-            .iter()
-            .filter(|standard| {
-                standard
-                    .common_variable_names
-                    .iter()
-                    .any(|name| name == variable_name)
-            })
-            .cloned()
-            .collect();
-
-        let py_filter = PyStandardsFilter { standards };
-        Py::new(py, py_filter)
+        let filtered = self.inner.by_variable_name(variable_name);
+        Py::new(py, PyStandardsFilter { inner: filtered })
     }
 
     /// Return standards by IOOS category
     fn by_ioos_category(&self, py: Python, category: &str) -> PyResult<Py<PyStandardsFilter>> {
-        let standards = self
-            .standards
-            .iter()
-            .filter(|standard| {
-                standard
-                    .ioos_category
-                    .as_ref()
-                    .is_some_and(|cat| cat.eq_ignore_ascii_case(category))
-            })
-            .cloned()
-            .collect();
-
-        let py_filter = PyStandardsFilter { standards };
-        Py::new(py, py_filter)
+        let filtered = self.inner.by_ioos_category(category);
+        Py::new(py, PyStandardsFilter { inner: filtered })
     }
 
     /// Return standards for a given unit
     fn by_unit(&self, py: Python, unit: &str) -> PyResult<Py<PyStandardsFilter>> {
-        let standards = self
-            .standards
-            .iter()
-            .filter(|standard| {
-                standard.unit == unit || standard.other_units.iter().any(|u| u == unit)
-            })
-            .cloned()
-            .collect();
-
-        let py_filter = PyStandardsFilter { standards };
-        Py::new(py, py_filter)
+        let filtered = self.inner.by_unit(unit);
+        Py::new(py, PyStandardsFilter { inner: filtered })
     }
 
     /// Return standards that have QARTOD tests
     fn has_qartod_tests(&self, py: Python) -> PyResult<Py<PyStandardsFilter>> {
-        let standards = self
-            .standards
-            .iter()
-            .filter(|standard| !standard.qartod.is_empty())
-            .cloned()
-            .collect();
-
-        let py_filter = PyStandardsFilter { standards };
-        Py::new(py, py_filter)
+        let filtered = self.inner.has_qartod_tests();
+        Py::new(py, PyStandardsFilter { inner: filtered })
     }
 
     /// Return standards that match a search pattern
     fn search(&self, py: Python, search_str: &str) -> PyResult<Py<PyStandardsFilter>> {
-        let mut search_index: SearchIndex<usize> = SearchIndex::default();
-
-        self.standards
-            .iter()
-            .enumerate()
-            .for_each(|(index, element)| search_index.insert(&index, element));
-        let results = search_index.search(search_str);
-
-        let mut standards: Vec<Standard> = Vec::new();
-        for index in results {
-            standards.push(self.standards[*index].clone());
-        }
-
-        standards.sort_by_key(|s| s.name.clone());
-
-        let py_filter = PyStandardsFilter { standards };
-        Py::new(py, py_filter)
+        let filtered = self.inner.search(search_str);
+        Py::new(py, PyStandardsFilter { inner: filtered })
     }
 
     /// Get a specific standard by name or alias
     fn get(&self, py: Python, standard_name_or_alias: &str) -> PyResult<Py<PyStandard>> {
-        for standard in &self.standards {
-            if standard.name == standard_name_or_alias
-                || standard
-                    .aliases
-                    .contains(&standard_name_or_alias.to_string())
-            {
+        match self.inner.get(standard_name_or_alias) {
+            Ok(standard) => {
                 let py_standard = PyStandard(standard.clone());
-                return Py::new(py, py_standard);
+                Py::new(py, py_standard)
             }
+            Err(_) => Err(PyKeyError::new_err("Unknown Standard")),
         }
-        Err(PyKeyError::new_err("Unknown Standard"))
     }
 
     /// Return the standards as a list
     fn __iter__(&self, py: Python) -> PyResult<Vec<Py<PyStandard>>> {
-        self.standards
+        self.inner
+            .standards
             .iter()
             .map(|standard| {
                 let py_standard = PyStandard(standard.clone());
@@ -138,13 +75,13 @@ impl PyStandardsFilter {
 
     /// Return the number of standards in the filter
     fn __len__(&self) -> usize {
-        self.standards.len()
+        self.inner.standards.len()
     }
 
     /// Get a standard by index
     fn __getitem__(&self, py: Python, index: usize) -> PyResult<Py<PyStandard>> {
-        if index < self.standards.len() {
-            let py_standard = PyStandard(self.standards[index].clone());
+        if index < self.inner.standards.len() {
+            let py_standard = PyStandard(self.inner.standards[index].clone());
             Py::new(py, py_standard)
         } else {
             Err(PyIndexError::new_err("Index out of range"))
@@ -154,7 +91,7 @@ impl PyStandardsFilter {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!(
             "<StandardsFilter: {} standards>",
-            self.standards.len()
+            self.inner.standards.len()
         ))
     }
 }


### PR DESCRIPTION
Simply filters by not re-implementing everything for each variant. This was done by converting the core filter to use owned standards, rather than having it reference them.
Further simplification
Even further

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #64 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #63 
<!-- GitButler Footer Boundary Bottom -->

