### PR TITLE
No WASM for PyPI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -156,6 +156,7 @@ jobs:
           merge-multiple: true
 
       - name: Remove unsupported pyodide wheel
+        working-directory: .
         run: rm -f dist/*pyodide_2024_0_wasm32*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -181,6 +182,7 @@ jobs:
           merge-multiple: true
 
       - name: Remove unsupported pyodide wheel
+        working-directory: .
         run: rm -f dist/*pyodide_2024_0_wasm32*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,7 +155,35 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Remove unsupported pyodide wheel
+        run: rm -f dist/*pyodide_2024_0_wasm32*.whl
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         # To test uploads to TestPyPI, uncomment the following:
         # with:
         #   repository-url: https://test.pypi.org/legacy/
+
+  upload_testpypi:
+    needs: [test, build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # environment: pypi
+    permissions:
+      id-token: write
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Remove unsupported pyodide wheel
+        run: rm -f dist/*pyodide_2024_0_wasm32*.whl
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # To test uploads to TestPyPI, uncomment the following:
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+readme = "Readme.md"
+description = "Programmatically augmenting CF Standards with operational knowledge."
+license = "Apache-2.0"
 
 [dependency-groups]
 dev = [
@@ -21,7 +24,7 @@ dev = [
 features = ["pyo3/extension-module"]
 module-name = "standard_knowledge._standard_knowledge_py"
 python-source = "python"
-exclude = ["README.md"]
+exclude = ["Readme.md"]
 
 
 [tool.uv]


### PR DESCRIPTION
PyPI doesn’t currently accept WASM wheels, so this should remove them from the upload, tests publishing against testpypi, and hopefully includes some of the documentation as well.

Closes #121