### PR TITLE
Fix TestPyPI failure and some Zizmor cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       - "/py"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: astral-sh/setup-uv
         uses: astral-sh/setup-uv@v7.2.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: "Set up Python"
         uses: actions/setup-python@v6
         with:
@@ -80,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure Rust nightly
         run: rustup default nightly
@@ -128,6 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -186,6 +192,6 @@ jobs:
         run: rm -f dist/*pyodide_2024_0_wasm32*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        # To test uploads to TestPyPI, uncomment the following:
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Output rust version for educational purposes
       run: rustup --version
     - name: Cache

--- a/.github/workflows/wasm-build-deploy.yml
+++ b/.github/workflows/wasm-build-deploy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Fixes the TestPyPI failure by allowing duplicates rather than erroring https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/#tolerating-release-package-file-duplicates

And does some Zizmor cleanup by removing the token after cloning the repo.