### PR TITLE
Bump to CIBuildWheel 4.1 to support WASM wheels

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -113,18 +113,8 @@ jobs:
         uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
-          # Pin Pyodide to 0.27.7 (uses Emscripten 3.1.58) to avoid Emscripten 4.0.9
-          # "invalid export name" issue with Rust-mangled symbols.
-          # See: https://github.com/emscripten-core/emscripten/issues/24825
-          CIBW_PYODIDE_VERSION: ${{ matrix.os == 'pyodide' && '314.0.0' || '' }}
-          # Pyodide 0.27.7 only supports Python 3.13, so limit the build for pyodide
-          CIBW_BUILD: ${{ matrix.os == 'pyodide' && 'cp314-*' || '*' }}
-        #   CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
-        # Can also be configured directly, using `with:`
         with:
           package-dir: py
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,7 +106,7 @@ jobs:
         run: rustup target add i686-pc-windows-msvc
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           # Pin Pyodide to 0.27.7 (uses Emscripten 3.1.58) to avoid Emscripten 4.0.9
@@ -161,10 +161,6 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Remove unsupported pyodide wheel
-        working-directory: .
-        run: rm -f dist/*pyodide_2024_0_wasm32*.whl
-
       - uses: pypa/gh-action-pypi-publish@release/v1
         # To test uploads to TestPyPI, uncomment the following:
         # with:
@@ -186,10 +182,6 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
-
-      - name: Remove unsupported pyodide wheel
-        working-directory: .
-        run: rm -f dist/*pyodide_2024_0_wasm32*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,10 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -112,9 +116,9 @@ jobs:
           # Pin Pyodide to 0.27.7 (uses Emscripten 3.1.58) to avoid Emscripten 4.0.9
           # "invalid export name" issue with Rust-mangled symbols.
           # See: https://github.com/emscripten-core/emscripten/issues/24825
-          CIBW_PYODIDE_VERSION: ${{ matrix.os == 'pyodide' && '0.27.7' || '' }}
-          # Pyodide 0.27.7 only supports Python 3.12, so limit the build for pyodide
-          CIBW_BUILD: ${{ matrix.os == 'pyodide' && 'cp312-*' || '*' }}
+          CIBW_PYODIDE_VERSION: ${{ matrix.os == 'pyodide' && '314.0.0' || '' }}
+          # Pyodide 0.27.7 only supports Python 3.13, so limit the build for pyodide
+          CIBW_BUILD: ${{ matrix.os == 'pyodide' && 'cp314-*' || '*' }}
         #   CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
         # Can also be configured directly, using `with:`
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Pin Rust version for pyodide (Emscripten 3.1.58 compatibility)
         if: matrix.os == 'pyodide'
         run: |
-          rustup install nightly-2025-01-20
-          rustup default nightly-2025-01-20
+          rustup install 1.93.0
+          rustup default 1.93.0
 
       - name: Add wasm32-unknown-emscripten target if pyodide
         if: matrix.os == 'pyodide'

--- a/README.md
+++ b/README.md
@@ -221,3 +221,15 @@ It will also pick up changes in Rust, both for the Python bindings and changes i
 ### Utils
 
 - `utils/update_standards.py` - Run with `uv run --script utils/update_standards.py` to update the standard names and alias files from CF Conventions that are imported into the Rust library.
+
+### Nox
+
+`./noxfile` has helpers for testing, bumping versions, updating standards, and other things that are easy to forget how to do.
+
+Unless a session is specified, Nox will run all but `release` sessions.
+
+Sessions (use `-s`):
+- `release` -- <patch|minor|major> - Bumps the version of the all the packages for a release.
+- `test_ptyhon-<version>` - Test a Python version as specified in the Github actions matrix.
+- `wheel` - Build Linux wheels for currently supported Python versions.
+- `wheel_wasm` - Build 3.14 WASM wheel.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["nox", "pyyaml"]
+# ///
+"""Test against the same matrix as Github Actions, build wheels, and
+bump versions for release."""
+
+import argparse
+
+import nox
+import yaml
+
+nox.needs_version = ">= 2025.10.14"
+nox.options.default_venv_backend = "uv|virtualenv"
+
+with open("./.github/workflows/python.yml") as f:
+    workflow = yaml.safe_load(f)
+
+python_versions = workflow["jobs"]["test"]["strategy"]["matrix"]["python-version"]
+
+
+@nox.session(default=False)
+def release(session: nox.Session) -> None:
+    """
+    Kicks off an automated release process by bumping the package version.
+
+    Invokes cargo-edit set-version with the posarg setting the version.
+
+    Usage:
+    $ nox -s release -- [major|minor|patch]
+    """
+    parser = argparse.ArgumentParser(description="Release a semver version.")
+    parser.add_argument(
+        "version",
+        type=str,
+        nargs=1,
+        help="The type of semver release to make.",
+        choices={"major", "minor", "patch"},
+    )
+    args: argparse.Namespace = parser.parse_args(args=session.posargs)
+    version: str = args.version.pop()
+
+    session.log(f"Dry run bumping the {version!r} version to check for errors")
+    session.run("cargo", "set-version", "--dry-run", "--bump", version, external=True)
+
+    # If we get here, we should be good to go
+    # Let's do a final check for safety
+    confirm = input(
+        f"You are about to bump the {version!r} version. Are you sure? [y/n]: "
+    )
+
+    # Abort on anything other than 'y'
+    if confirm.lower().strip() != "y":
+        session.error(f"You said no when prompted to bump the {version!r} version.")
+
+    session.log(f"Bumping the {version!r} version")
+    session.run("cargo", "set-version", "--bump", version, external=True)
+
+
+@nox.session(python=python_versions)
+def test_python(session: nox.Session) -> None:
+    """Run the Python tests."""
+    session.cd("py")
+    session.run("uv", "run", "pytest")
+
+
+@nox.session
+def wheel(session: nox.Session) -> None:
+    """Build Linux wheels for multiple python versions"""
+    session.run("uvx", "cibuildwheel", "--platform", "linux", "py")
+
+
+@nox.session
+def wheel_wasm(session: nox.Session) -> None:
+    """Build a wheel for the pyodide target."""
+    session.run(
+        "uvx",
+        "cibuildwheel",
+        "--platform",
+        "pyodide",
+        "py",
+        env={
+            "RUSTUP_TOOLCHAIN": "nightly-2025-01-20",
+            "CIBW_BUILD": "cp314-pyodide_wasm32",
+            "CIBW_PYODIDE_VERSION": "314.0.0",
+        },
+    )
+
+
+if __name__ == "__main__":
+    nox.main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -80,11 +80,45 @@ def wheel_wasm(session: nox.Session) -> None:
         "pyodide",
         "py",
         env={
-            "RUSTUP_TOOLCHAIN": "nightly-2025-01-20",
+            # Must match the toolchain Pyodide expects for this version:
+            # `PYODIDE_ROOT=<xbuildenv> pyodide config get rust_toolchain`.
+            # For Pyodide 314.0.0 that is stable 1.93.0, whose
+            # wasm32-unknown-emscripten target defaults to native wasm
+            # exception handling (matching Pyodide's runtime). An older
+            # nightly defaults to the legacy Emscripten EH/SjLj ABI, which
+            # emits `invoke_*` imports the Pyodide runtime can't resolve
+            # ("Dynamic linking error: cannot resolve symbol invoke_i").
+            "RUSTUP_TOOLCHAIN": "1.93.0",
             "CIBW_BUILD": "cp314-pyodide_wasm32",
             "CIBW_PYODIDE_VERSION": "314.0.0",
         },
     )
+
+
+@nox.session(default=False, python=False)
+def test_wasm(session: nox.Session) -> None:
+    """Create a virtual environment for testing the pyodide wheel."""
+    python_path = ".venv-pyodide/bin/python"
+
+    session.run("pyodide", "venv", ".venv-pyodide")
+    session.run(
+        python_path,
+        "-m",
+        "pip",
+        "install",
+        "wheelhouse/standard_knowledge-0.1.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+    )
+
+    pyproject = nox.project.load_toml("py/pyproject.toml")
+    session.run(
+        python_path,
+        "-m",
+        "pip",
+        "install",
+        *nox.project.dependency_groups(pyproject, "dev"),
+    )
+
+    session.run(python_path, "-m", "pytest")
 
 
 if __name__ == "__main__":

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,19 +79,6 @@ def wheel_wasm(session: nox.Session) -> None:
         "--platform",
         "pyodide",
         "py",
-        env={
-            # Must match the toolchain Pyodide expects for this version:
-            # `PYODIDE_ROOT=<xbuildenv> pyodide config get rust_toolchain`.
-            # For Pyodide 314.0.0 that is stable 1.93.0, whose
-            # wasm32-unknown-emscripten target defaults to native wasm
-            # exception handling (matching Pyodide's runtime). An older
-            # nightly defaults to the legacy Emscripten EH/SjLj ABI, which
-            # emits `invoke_*` imports the Pyodide runtime can't resolve
-            # ("Dynamic linking error: cannot resolve symbol invoke_i").
-            "RUSTUP_TOOLCHAIN": "1.93.0",
-            "CIBW_BUILD": "cp314-pyodide_wasm32",
-            "CIBW_PYODIDE_VERSION": "314.0.0",
-        },
     )
 
 

--- a/py/Readme.md
+++ b/py/Readme.md
@@ -31,13 +31,15 @@ under_pressure = library.filter().search("pressure")
 
 ## Testing
 
-Test with `uv run pytest`
+Test with `uv run pytest`, or `../noxfile.py -s test_python` to test against multiple versions.
 
 ## Building
 
 Run `uvx cibuildwheel --platform linux py` from the top of the repo to build.
 
 Note: [cibuildwheel only uses official builds](https://github.com/pypa/cibuildwheel/issues/2502), so it'll get ornery with Python from other sources (uv, Pixi, Brew).
+
+`../noxfile.py -s wheel` should run that as well.
 
 ### Building Pyodide/WASM wheels locally
 Pyodide wheels require specific Rust and Pyodide versions due to Emscripten compatibility:
@@ -47,4 +49,7 @@ rustup install nightly-2025-01-20
 rustup target add wasm32-unknown-emscripten --toolchain nightly-2025-01-20
 
 # Build pyodide wheels with pinned Rust toolchain and Pyodide 0.27.7
-RUSTUP_TOOLCHAIN=nightly-2025-01-20 CIBW_PYODIDE_VERSION=0.27.7 uvx cibuildwheel --platform pyodide py
+RUSTUP_TOOLCHAIN=nightly-2025-01-20 CIBW_BUILD=cp314-pyodide_wasm32 CIBW_PYODIDE_VERSION=314.0.0 uvx cibuildwheel --platform pyodide py
+```
+
+Try using `../noxfile.py -s wheel_wasm` which should encapsulate those commands.

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -37,3 +37,10 @@ cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "src/**/
 # Run the package tests using `pytest` after building wheels
 test-groups = ["dev"]
 test-command = "python -m pytest {project}/py/tests -xv"
+skip = [
+    "cp313-pyodide_wasm32", # not compatible with the pyodide version
+]
+
+[tool.cibuildwheel.pyodide]
+pyodide-version = "314.0.0"
+environment = {"RUSTUP_TOOLCHAIN" = "1.93.0"}

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -32,3 +32,8 @@ exclude = ["Readme.md"]
 cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "src/**/*.rs"}, {file = "python/**/*.py"}, {file = "../core/standards/*.yaml"}, {file = "../core/src/**/*.rs"}]
 # Uncomment to build rust code in development mode
 # config-settings = { build-args = '--profile=dev' }
+
+[tool.cibuildwheel]
+# Run the package tests using `pytest` after building wheels
+test-groups = ["dev"]
+test-command = "python -m pytest {project}/py/tests -xv"


### PR DESCRIPTION
PyPI now support WASM wheels, so bumping to the version of CIBuildWheel that correctly formats them and removes our cleanup step.

Adds testing of wheels, and bumps the Rust version to one that will link the right things.