### PR TITLE
Tweak release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - "feature"
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "bug"
+    - title: "Other Changes"
+      labels:
+        - "*"
+    - title: "Dependency Updates"
+      labels:
+        - "dependencies"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     hooks:
       - id: zizmor
         files: "^\\.github"
+        exclude: ".github/release.yml"
         args: [--persona=pedantic]
 
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
Configures categories and tries to seperate out Dependabot.