### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,9 @@ changelog:
     - title: "Other Changes"
       labels:
         - "*"
+      exclude:
+        labels:
+          - "dependencies"
     - title: "Dependency Updates"
       labels:
         - "dependencies"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standard_knowledge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dyn-clone",
  "flate2",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "standard_knowledge_cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "reqwest",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "standard_knowledge_js"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console_error_panic_hook",
  "indicium",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "standard_knowledge_py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dyn-clone",
  "indicium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [ "cli", "core", "js", "py"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 repository = "https://github.com/ioos/standard_knowledge/"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ Knowledge keys:
 
 Cargo as manages the Rust components of the project, while Maturin and uv help keep things inline when working from the Python side of things.
 
+### Releasing
+
+Use `./noxfile.py -s release -- <patch|minor|major>` to bump the version.
+Preferbly in a PR with the changes from the last release included.
+
 ### Rust Testing
 
 `cargo test` will run tests in all the workspaces.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.54", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
-standard_knowledge = { path = "../core", version = "0.1.0" }
+standard_knowledge = { path = "../core", version = "0.1.1" }
 reqwest = { version = "0.13", features = ["blocking"] }
 serde = { version = "1.0.228", features = ["derive"] }
 

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -16,7 +16,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-standard_knowledge = { path = "../core", version = "0.1.0" }
+standard_knowledge = { path = "../core", version = "0.1.1" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -15,6 +15,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.29.0"
-standard_knowledge = { path = "../core", version = "0.1.0" }
+standard_knowledge = { path = "../core", version = "0.1.1" }
 dyn-clone = "1.0.20"
 indicium = "0.6.5"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🚀 Features
* Bump to CIBuildWheel 4.1 to support WASM wheels by @abkfenris in https://github.com/ioos/standard_knowledge/pull/144
* Configure Crates.io publishing by @abkfenris in https://github.com/ioos/standard_knowledge/pull/146
* Javascript testing and publishing by @abkfenris in https://github.com/ioos/standard_knowledge/pull/148
### 🐛 Bug Fixes
* Fix TestPyPI failure and some Zizmor cleanup by @abkfenris in https://github.com/ioos/standard_knowledge/pull/138
### Other Changes
* No WASM for PyPI by @abkfenris in https://github.com/ioos/standard_knowledge/pull/122
* Update renovate config with cooldowns and pinning by @abkfenris in https://github.com/ioos/standard_knowledge/pull/137
* Update standards and run rust test by @abkfenris in https://github.com/ioos/standard_knowledge/pull/145
* Add navd88 as a column name by @abkfenris in https://github.com/ioos/standard_knowledge/pull/147
* Zizmor, GHA, and deps cleanup by @abkfenris in https://github.com/ioos/standard_knowledge/pull/149
* Further cleanup with repo-review by @abkfenris in https://github.com/ioos/standard_knowledge/pull/157
* Group Vite dependencies by @abkfenris in https://github.com/ioos/standard_knowledge/pull/164
* Tweak release note generation by @abkfenris in https://github.com/ioos/standard_knowledge/pull/168
### Dependency updates
* Bump vite from 7.1.10 to 8.0.16 in /js by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/154
* Update maturin requirement from <2.0,>=1.9 to >=1.14.0,<2.0 in /py by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/155
* Bump @biomejs/biome from 2.1.1 to 2.5.0 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/151
* Bump pyo3 from 0.27.2 to 0.29.0 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/159
* Bump flate2 from 1.1.8 to 1.1.9 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/163
* Bump black from 24.0.dev to 26.5.1 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/158
* Bump trycmd from 0.15.11 to 1.2.0 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/160
* Bump wasm-bindgen-test from 0.3.58 to 0.3.73 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/162
* Bump pypa/cibuildwheel from a0a973acdc9e7b7f8b04ac5c80e6883a5a102615 to 294735312765b09d24a2fbec22660ce817587d55 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/161
* Bump https://github.com/python-jsonschema/check-jsonschema from 0.37.2 to 0.37.3 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/165
* Bump the vite group in /js with 2 updates by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/166
* Bump quinn-proto from 0.11.13 to 0.11.14 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/167
* Bump rustls-webpki from 0.103.4 to 0.103.13 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/169
* Bump rand from 0.9.2 to 0.9.4 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/170
* Bump bytes from 1.10.1 to 1.12.0 by @dependabot[bot] in https://github.com/ioos/standard_knowledge/pull/171


**Full Changelog**: https://github.com/ioos/standard_knowledge/compare/v0.1.0...v0.1.1