### PR TITLE
Feature gate for embedding data

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
   pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -42,11 +42,11 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       id: run-tests
-      run: cargo test --verbose
+      run: cargo test --verbose --no-default-features
       continue-on-error: true
-    - name: Dump test fixtures on failure
+    - name: Dump test fixtures on failure  --no-default-features
       if: steps.run-tests.outcome == 'failure'
-      run: TRYCMD=dump cargo test --verbose
+      run: TRYCMD=dump cargo test --verbose  --no-default-features
       continue-on-error: true
     - name: Upload updated fixtures
       if: steps.run-tests.outcome == 'failure'
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # OIDC trusted-publishing token for crates.io
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
  "flate2",
  "indicium",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,10 @@ description.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["embedded-data"]
+embedded-data = ["dep:flate2"]
+
 [build-dependencies]
 serde_yaml_ng = "0.10"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -21,5 +25,6 @@ path = "src/main.rs"
 dyn-clone = "1.0.20"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml_ng = "0.10"
-flate2 = "1.1"
+serde_json = "1"
+flate2 = { version = "1.1", optional = true }
 indicium = "0.6.5"

--- a/core/build.rs
+++ b/core/build.rs
@@ -124,8 +124,10 @@ fn write_knowledge() {
 }
 
 fn main() {
-    write_cf_standards_from_yaml();
-    write_knowledge();
+    if std::env::var("CARGO_FEATURE_EMBEDDED_DATA").is_ok() {
+        write_cf_standards_from_yaml();
+        write_knowledge();
+    }
 
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rerun-if-changed=standards/")

--- a/core/src/cf.rs
+++ b/core/src/cf.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
-use std::io::Read;
 
-use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 
 use crate::standard::Standard;
@@ -16,18 +14,6 @@ struct CfYaml {
 struct CfStandard {
     description: String,
     unit: String,
-}
-
-fn load_cf_yaml() -> CfYaml {
-    let compressed_data = include_bytes!(concat!(env!("OUT_DIR"), "/cf_standards.yaml.gz"));
-
-    // Decompress the data
-    let mut decoder = GzDecoder::new(&compressed_data[..]);
-    let mut yaml_data = String::new();
-    decoder.read_to_string(&mut yaml_data).unwrap();
-
-    // Deserialize from YAML
-    serde_yaml_ng::from_str(&yaml_data).unwrap()
 }
 
 /// Returns a HashMap of standard names: vector of aliases
@@ -46,17 +32,12 @@ fn aliases_by_standard_name(cf_yaml: &CfYaml) -> HashMap<String, Vec<String>> {
     standards
 }
 
-/// Returns a HashMap of standard names to Standard
-pub fn cf_standards() -> HashMap<String, Standard> {
-    let cf_yaml = load_cf_yaml();
+fn cf_yaml_to_standards(cf_yaml: CfYaml) -> HashMap<String, Standard> {
     let alias_map = aliases_by_standard_name(&cf_yaml);
-
     let mut standards = HashMap::new();
-
     for (name, cf_standard) in &cf_yaml.standard_names {
         let empty_vec = Vec::new();
         let aliases = alias_map.get(name).unwrap_or(&empty_vec);
-
         standards.insert(
             name.to_string(),
             Standard {
@@ -68,14 +49,51 @@ pub fn cf_standards() -> HashMap<String, Standard> {
             },
         );
     }
-
     standards
+}
+
+#[cfg(feature = "embedded-data")]
+fn load_cf_yaml() -> CfYaml {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let compressed_data = include_bytes!(concat!(env!("OUT_DIR"), "/cf_standards.yaml.gz"));
+
+    // Decompress the data
+    let mut decoder = GzDecoder::new(&compressed_data[..]);
+    let mut yaml_data = String::new();
+    decoder.read_to_string(&mut yaml_data).unwrap();
+
+    // Deserialize from YAML
+    serde_yaml_ng::from_str(&yaml_data).unwrap()
+}
+
+/// Returns a HashMap of standard names to Standard from the embedded compressed data.
+#[cfg(feature = "embedded-data")]
+pub fn cf_standards() -> HashMap<String, Standard> {
+    let cf_yaml = load_cf_yaml();
+    cf_yaml_to_standards(cf_yaml)
+}
+
+/// Returns CF standards by deserializing a YAML string.
+pub fn cf_standards_from_yaml(yaml: &str) -> Result<HashMap<String, Standard>, String> {
+    serde_yaml_ng::from_str::<CfYaml>(yaml)
+        .map(cf_yaml_to_standards)
+        .map_err(|e| e.to_string())
+}
+
+/// Returns CF standards by deserializing a JSON string.
+pub fn cf_standards_from_json(json: &str) -> Result<HashMap<String, Standard>, String> {
+    serde_json::from_str::<CfYaml>(json)
+        .map(cf_yaml_to_standards)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn load_cf_standards() {
         let standards = cf_standards();
@@ -92,8 +110,12 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn test_compressed_loading() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
         // Load the compressed data directly to ensure compression is working
         let compressed_data = include_bytes!(concat!(env!("OUT_DIR"), "/cf_standards.yaml.gz"));
 
@@ -119,5 +141,35 @@ mod tests {
             compressed_data.len() < 1_000_000,
             "Compressed data should be less than 1MB"
         );
+    }
+
+    #[test]
+    fn cf_standards_from_yaml_roundtrip() {
+        let yaml = r#"
+aliases:
+  air_pressure_at_sea_level: air_pressure_at_mean_sea_level
+standard_names:
+  air_pressure_at_mean_sea_level:
+    description: Air pressure at mean sea level
+    unit: Pa
+"#;
+        let standards = cf_standards_from_yaml(yaml).unwrap();
+        let p = &standards["air_pressure_at_mean_sea_level"];
+        assert_eq!(p.unit, "Pa");
+        assert!(p.aliases.contains(&"air_pressure_at_sea_level".to_string()));
+    }
+
+    #[test]
+    fn cf_standards_from_json_roundtrip() {
+        let json = r#"{
+  "aliases": {"air_pressure_at_sea_level": "air_pressure_at_mean_sea_level"},
+  "standard_names": {
+    "air_pressure_at_mean_sea_level": {"description": "Air pressure at mean sea level", "unit": "Pa"}
+  }
+}"#;
+        let standards = cf_standards_from_json(json).unwrap();
+        let p = &standards["air_pressure_at_mean_sea_level"];
+        assert_eq!(p.unit, "Pa");
+        assert!(p.aliases.contains(&"air_pressure_at_sea_level".to_string()));
     }
 }

--- a/core/src/knowledge_include.rs
+++ b/core/src/knowledge_include.rs
@@ -11,18 +11,23 @@ pub struct Knowledge {
     pub ioos_category: Option<String>,
 
     /// Common variable names in a dataset
+    #[serde(default)]
     pub common_variable_names: Vec<String>,
 
     /// Other standards to consider
+    #[serde(default)]
     pub related_standards: Vec<String>,
 
     /// Standards that are usually used together
+    #[serde(default)]
     pub sibling_standards: Vec<String>,
 
     /// Extra attributes that are usually included in Xarray or NetCDF metadata
+    #[serde(default)]
     pub extra_attrs: BTreeMap<String, String>,
 
     /// Other units that may be seen
+    #[serde(default)]
     pub other_units: Vec<String>,
 
     /// Community comments on standard usage

--- a/core/src/library_knowledge.rs
+++ b/core/src/library_knowledge.rs
@@ -1,9 +1,10 @@
-use flate2::read::GzDecoder;
-use std::io::Read;
-
 use crate::knowledge::Knowledge;
 
+#[cfg(feature = "embedded-data")]
 pub fn load_knowledge() -> Vec<Knowledge> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
     let compressed_data = include_bytes!(concat!(env!("OUT_DIR"), "/knowledge.yaml.gz"));
 
     // Decompress the data
@@ -15,4 +16,14 @@ pub fn load_knowledge() -> Vec<Knowledge> {
     let knowledge: Vec<Knowledge> = serde_yaml_ng::from_str(&yaml_data).unwrap();
 
     knowledge
+}
+
+/// Deserializes knowledge from a YAML string.
+pub fn load_knowledge_from_yaml(yaml: &str) -> Result<Vec<Knowledge>, String> {
+    serde_yaml_ng::from_str(yaml).map_err(|e| e.to_string())
+}
+
+/// Deserializes knowledge from a JSON string.
+pub fn load_knowledge_from_json(json: &str) -> Result<Vec<Knowledge>, String> {
+    serde_json::from_str(json).map_err(|e| e.to_string())
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -2,6 +2,7 @@ use standard_knowledge::standards_library::StandardsLibrary;
 
 fn main() {
     let mut library = StandardsLibrary::default();
+    #[cfg(feature = "embedded-data")]
     library.load_cf_standards();
     println!(
         "By name: {:?}",

--- a/core/src/standards_library.rs
+++ b/core/src/standards_library.rs
@@ -10,11 +10,32 @@ pub struct StandardsLibrary {
 }
 
 impl StandardsLibrary {
-    /// Load CF standards from library
+    /// Load CF standards from the embedded compressed data.
+    #[cfg(feature = "embedded-data")]
     pub fn load_cf_standards(&mut self) {
         use crate::cf::cf_standards;
 
         self.standards.extend(cf_standards());
+    }
+
+    /// Load CF standards from a YAML string.
+    pub fn load_cf_standards_from_yaml(&mut self, yaml: &str) -> Result<(), String> {
+        self.standards
+            .extend(crate::cf::cf_standards_from_yaml(yaml)?);
+        Ok(())
+    }
+
+    /// Load CF standards from a JSON string.
+    pub fn load_cf_standards_from_json(&mut self, json: &str) -> Result<(), String> {
+        self.standards
+            .extend(crate::cf::cf_standards_from_json(json)?);
+        Ok(())
+    }
+
+    /// Load CF standards from an already-deserialized vec.
+    pub fn load_cf_standards_from_vec(&mut self, standards: Vec<Standard>) {
+        self.standards
+            .extend(standards.into_iter().map(|s| (s.name.clone(), s)));
     }
 
     pub fn filter(&self) -> StandardsFilter {
@@ -77,10 +98,25 @@ impl StandardsLibrary {
         }
     }
 
-    /// Load community knowledge
+    /// Load community knowledge from the embedded compressed data.
+    #[cfg(feature = "embedded-data")]
     pub fn load_knowledge(&mut self) {
         let knowledge = crate::library_knowledge::load_knowledge();
         self.apply_knowledge(knowledge);
+    }
+
+    /// Load community knowledge from a YAML string.
+    pub fn load_knowledge_from_yaml(&mut self, yaml: &str) -> Result<(), String> {
+        let knowledge = crate::library_knowledge::load_knowledge_from_yaml(yaml)?;
+        self.apply_knowledge(knowledge);
+        Ok(())
+    }
+
+    /// Load community knowledge from a JSON string.
+    pub fn load_knowledge_from_json(&mut self, json: &str) -> Result<(), String> {
+        let knowledge = crate::library_knowledge::load_knowledge_from_json(json)?;
+        self.apply_knowledge(knowledge);
+        Ok(())
     }
 
     /// Load test suites
@@ -112,12 +148,46 @@ impl StandardsLibrary {
 mod tests {
     use super::*;
 
+    const FIXTURE_CF_YAML: &str = r#"
+aliases:
+  air_pressure_at_sea_level: air_pressure_at_mean_sea_level
+standard_names:
+  air_pressure_at_mean_sea_level:
+    description: Air pressure at mean sea level
+    unit: Pa
+  sea_surface_wave_mean_period:
+    description: Mean wave period
+    unit: s
+"#;
+
+    const FIXTURE_CF_JSON: &str = r#"{
+  "aliases": {"air_pressure_at_sea_level": "air_pressure_at_mean_sea_level"},
+  "standard_names": {
+    "air_pressure_at_mean_sea_level": {"description": "Air pressure at mean sea level", "unit": "Pa"}
+  }
+}"#;
+
+    const FIXTURE_KNOWLEDGE_YAML: &str = r#"
+- name: air_pressure_at_mean_sea_level
+  long_name: Air Pressure at Sea Level
+  common_variable_names:
+    - pressure
+    - airPressure
+"#;
+
+    const FIXTURE_KNOWLEDGE_JSON: &str = r#"[
+  {"name": "air_pressure_at_mean_sea_level", "long_name": "Air Pressure at Sea Level",
+   "common_variable_names": ["pressure"]}
+]"#;
+
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_load_standards() {
         let mut library = StandardsLibrary::default();
         library.load_cf_standards();
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_get_standard() {
         let mut library = StandardsLibrary::default();
@@ -126,6 +196,7 @@ mod tests {
         assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_get_standard_by_alias() {
         let mut library = StandardsLibrary::default();
@@ -134,6 +205,7 @@ mod tests {
         assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_apply_knowledge() {
         let mut library = StandardsLibrary::default();
@@ -160,6 +232,7 @@ mod tests {
         assert_ne!(pressure, updated_pressure);
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_find_by_variable_name() {
         let mut library = StandardsLibrary::default();
@@ -178,6 +251,7 @@ mod tests {
         assert_eq!(pressure.name, "air_pressure_at_mean_sea_level");
     }
 
+    #[cfg(feature = "embedded-data")]
     #[test]
     fn can_find_by_variable_name_case_insensitive() {
         let mut library = StandardsLibrary::default();
@@ -213,5 +287,63 @@ mod tests {
         let filtered = library.filter().by_variable_name("AIR_PRESSURE");
         assert_eq!(filtered.standards.len(), 1);
         assert_eq!(filtered.standards[0].name, "air_pressure_at_mean_sea_level");
+    }
+
+    #[test]
+    fn load_cf_standards_from_yaml_works() {
+        let mut library = StandardsLibrary::default();
+        library
+            .load_cf_standards_from_yaml(FIXTURE_CF_YAML)
+            .unwrap();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(pressure.unit, "Pa");
+        assert!(pressure
+            .aliases
+            .contains(&"air_pressure_at_sea_level".to_string()));
+    }
+
+    #[test]
+    fn load_cf_standards_from_json_works() {
+        let mut library = StandardsLibrary::default();
+        library
+            .load_cf_standards_from_json(FIXTURE_CF_JSON)
+            .unwrap();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(pressure.unit, "Pa");
+    }
+
+    #[test]
+    fn load_knowledge_from_yaml_works() {
+        let mut library = StandardsLibrary::default();
+        library
+            .load_cf_standards_from_yaml(FIXTURE_CF_YAML)
+            .unwrap();
+        library
+            .load_knowledge_from_yaml(FIXTURE_KNOWLEDGE_YAML)
+            .unwrap();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(
+            pressure.long_name.as_deref(),
+            Some("Air Pressure at Sea Level")
+        );
+        assert!(pressure
+            .common_variable_names
+            .contains(&"pressure".to_string()));
+    }
+
+    #[test]
+    fn load_knowledge_from_json_works() {
+        let mut library = StandardsLibrary::default();
+        library
+            .load_cf_standards_from_yaml(FIXTURE_CF_YAML)
+            .unwrap();
+        library
+            .load_knowledge_from_json(FIXTURE_KNOWLEDGE_JSON)
+            .unwrap();
+        let pressure = library.get("air_pressure_at_mean_sea_level").unwrap();
+        assert_eq!(
+            pressure.long_name.as_deref(),
+            Some("Air Pressure at Sea Level")
+        );
     }
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -159,6 +159,29 @@ def rust_test(session: nox.Session) -> None:
 
 
 @nox.session(python=False, default=False)
+def rust_test_no_embedded(session: nox.Session) -> None:
+    """Run core Rust tests without the embedded-data feature.
+
+    Verifies the JS-build path: YAML-string and JSON-string ingestion work
+    without the compressed blobs compiled in.
+    """
+    venv = os.environ.pop("VIRTUAL_ENV", None)
+    if venv:
+        session.warn(
+            f"Ignoring VIRTUAL_ENV={venv!r} so cargo/PyO3 builds against the "
+            "host Python interpreter."
+        )
+    session.run(
+        "cargo",
+        "test",
+        "-p",
+        "standard_knowledge",
+        "--no-default-features",
+        external=True,
+    )
+
+
+@nox.session(python=False, default=False)
 def rust_update_tests(session: nox.Session) -> None:
     """Update the Rust test fixtures."""
     session.run(


### PR DESCRIPTION
Add `embedded-data` cargo feature (default) that wraps the
include_bytes!/flate2 path. py/cli build with defaults unchanged.
New ingestion methods accept YAML strings, JSON strings, or a
pre-deserialized Vec, letting the JS wasm receive data externally.
Knowledge struct Vec fields now have #[serde(default)] for partial-doc
ingestion. New nox session rust_test_no_embedded verifies the
no-embedded path (11 tests).

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #182 
- <kbd>&nbsp;5&nbsp;</kbd> #181 
- <kbd>&nbsp;4&nbsp;</kbd> #180 
- <kbd>&nbsp;3&nbsp;</kbd> #179 
- <kbd>&nbsp;2&nbsp;</kbd> #178 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #177 
<!-- GitButler Footer Boundary Bottom -->

